### PR TITLE
Added support for bGeigie3 device in bgeigie_import.rb

### DIFF
--- a/app/models/bgeigie_import.rb
+++ b/app/models/bgeigie_import.rb
@@ -114,7 +114,7 @@ class BgeigieImport < MeasurementImport
     return false unless line_items.length == 15
 
     #check header
-    return false unless line_items[0].eql? '$BMRDD' or line_items[0].eql? '$BGRDD' or line_items[0].eql? '$BNRDD'
+    return false unless line_items[0].eql? '$BMRDD' or line_items[0].eql? '$BGRDD' or line_items[0].eql? '$BNRDD' or line_items[0].eql? '$BNXRDD'
 
     #check for Valid CPM 
     return false unless line_items[6].eql? 'A' or line_items[6].eql? 'V'


### PR DESCRIPTION
The new bGeigie3 device uses a different device identifier in its log files.
It was sufficient to add an additional clause in an if in bgeigie_import.rb.
