### PR TITLE
Remove pgpass from repo tree

### DIFF
--- a/doc/.pgpass
+++ b/doc/.pgpass
@@ -1,1 +1,0 @@
-*:5432:safecastapi:deploy:dQ6TWlplvw


### PR DESCRIPTION
We could also do a filter branch but I confirmed that this is not in use on dev, staging or prod so won't worry about that until after this is reviewed/merged.

Dev is the only environment with a `deploy` user, but this is not the password for that user.

Connected to #179