### PR TITLE
Remove attempt to force postgis extension creation

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,9 +1,0 @@
-namespace :db do
-  #NOTE: Newer versions of rails should support this in schema.rb. Ours doesn't atm.
-  desc 'Creates the postgis extension on the datatabase'
-  task :enable_postgis => :environment do
-    connection = ActiveRecord::Base.connection
-    connection.exec_query('CREATE EXTENSION IF NOT EXISTS postgis')
-  end
-end
-task 'db:schema:load' => 'db:enable_postgis'


### PR DESCRIPTION
This was originally added for the c66 staging setup, but seems to cause trouble locally, so I'll just drop it for now.