### PR TITLE
Update eventmachine gem to 1.0.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       launchy (~> 2.1)
       mail (~> 2.2)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.9.1)
     excon (0.20.1)
     execjs (1.4.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
1.0.9.1 fixes some compilation errors On OS X 10.10. (See https://github.com/eventmachine/eventmachine/pull/668)