### PR TITLE
Use -i option when executing pg_dump if its version is less than 9.0.0

### DIFF
--- a/config/initializers/postgis.rb
+++ b/config/initializers/postgis.rb
@@ -13,7 +13,9 @@ require 'rake'
   username = config['username']
   filename = ::Rails.root.join('db', 'structure.sql')
   database = config['database']
-  `pg_dump -i -U "#{ username }" -s -x -O -f #{ filename } #{ database }`
+  `pg_dump -U "#{ username }" -s -x -O -f #{ filename } #{ database }`
+
+
   
   File.open(filename, 'a') { |f|
     f.puts ActiveRecord::Base.connection.dump_schema_information


### PR DESCRIPTION
This PR changes to use `-i` option in `pg_dump` command only when `pg_dump` version is less than 9.0 because

1. From version 9.5, `pg_dump` returns error ("invalid option").
2. This option ( `-i` or `--ignore-version`) is "A deprecated option that is now ignored." in `pg_dump` version 9.[0-4].