### PR TITLE
Add specs for more coverages

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--order rand
+--require 'spec_helper'

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'thin'
 
 group :test do
   gem "codeclimate-test-reporter", require: nil
-  gem 'capybara', '~> 2.1.0'
+  gem 'capybara'
   gem 'database_cleaner'
   gem 'fabrication', '2.2.2'
   gem 'launchy'

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :test do
   gem 'fabrication', '2.2.2'
   gem 'launchy'
   gem 'pry'
-  gem 'rspec-rails',            '~> 2.12.2'
+  gem 'rspec-rails', '~> 2.99.0'
   gem 'email_spec'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :test do
   gem 'fabrication', '2.2.2'
   gem 'launchy'
   gem 'pry'
+  gem 'rspec-its'
   gem 'rspec-rails', '~> 2.99.0'
   gem 'email_spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,8 @@ GEM
       sass (~> 3.2)
     builder (3.0.4)
     cancan (1.6.8)
-    capybara (2.1.0)
+    capybara (2.7.1)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -147,7 +148,7 @@ GEM
       net-ssh (>= 1.99.1)
     net-ssh (2.6.7)
     newrelic_rpm (3.12.1.298)
-    nokogiri (1.5.9)
+    nokogiri (1.5.11)
     orm_adapter (0.4.0)
     pg (0.15.1)
     polyglot (0.3.5)
@@ -163,7 +164,7 @@ GEM
       yajl-ruby (~> 1.1.0)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
-    rack (1.4.5)
+    rack (1.4.7)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-pjax (0.7.0)
@@ -288,7 +289,7 @@ DEPENDENCIES
   bootstrap-kaminari-views
   bootstrap-sass (~> 2.2.2.0)
   cancan
-  capybara (~> 2.1.0)
+  capybara
   carrierwave (~> 0.6.2)
   codeclimate-test-reporter
   coffee-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       railties (~> 3.1)
       warden (~> 1.2.1)
     devise-i18n (0.8.3)
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.5)
     docile (1.1.5)
     dotenv (2.0.1)
     dotenv-rails (2.0.1)
@@ -214,17 +214,21 @@ GEM
       activerecord (>= 3.0.3)
       arel (>= 2.0.6)
       rgeo (>= 0.3.20)
-    rspec-core (2.12.2)
-    rspec-expectations (2.12.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.12.2)
-    rspec-rails (2.12.2)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+    rspec-rails (2.99.0)
       actionpack (>= 3.0)
+      activemodel (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
-      rspec-core (~> 2.12.0)
-      rspec-expectations (~> 2.12.0)
-      rspec-mocks (~> 2.12.0)
+      rspec-collection_matchers
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
     ruby-hmac (0.4.0)
     safe_yaml (0.9.3)
     sass (3.2.8)
@@ -316,7 +320,7 @@ DEPENDENCIES
   rails (= 3.2.21)
   rails_admin
   redcarpet
-  rspec-rails (~> 2.12.2)
+  rspec-rails (~> 2.99.0)
   sass-rails
   simple_form (~> 2.0.4)
   skylight
@@ -324,5 +328,8 @@ DEPENDENCIES
   uglifier
   unicorn
 
+RUBY VERSION
+   ruby 2.0.0p648
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,9 @@ GEM
     rspec-core (2.99.2)
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-mocks (2.99.4)
     rspec-rails (2.99.0)
       actionpack (>= 3.0)
@@ -320,6 +323,7 @@ DEPENDENCIES
   rails (= 3.2.21)
   rails_admin
   redcarpet
+  rspec-its
   rspec-rails (~> 2.99.0)
   sass-rails
   simple_form (~> 2.0.4)

--- a/spec/acceptance/count_is_public_spec.rb
+++ b/spec/acceptance/count_is_public_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Publicly viewable measurement count' do
+feature 'Publicly viewable measurement count', type: :feature do
   let(:user) { Fabricate(:user) }
   let!(:m1) { Fabricate(:measurement, :value => 66, :user_id => user.id) }
   let!(:m2) { Fabricate(:measurement, :value => 60, :user_id => user.id) }

--- a/spec/acceptance/count_is_public_spec.rb
+++ b/spec/acceptance/count_is_public_spec.rb
@@ -11,6 +11,6 @@ feature 'Publicly viewable measurement count' do
 
   scenario 'view http://maps.safecast.org/count' do
     visit('/count')
-    page.should have_content('6 measurements')
+    expect(page).to have_content('6 measurements')
   end
 end

--- a/spec/acceptance/guest_signs_up_spec.rb
+++ b/spec/acceptance/guest_signs_up_spec.rb
@@ -9,7 +9,7 @@ feature "Guest signs up" do
       new_user.save
       new_user.password = "mynewpassword"
       sign_in(new_user)
-      page.should have_content("Sign out")
+      expect(page).to have_content("Sign out")
     end
   end
 end

--- a/spec/acceptance/guest_signs_up_spec.rb
+++ b/spec/acceptance/guest_signs_up_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "Guest signs up" do
+feature "Guest signs up", type: :feature do
   context "as a new user" do
     scenario "signing up" do
       sign_up

--- a/spec/acceptance/user_creates_a_device_spec.rb
+++ b/spec/acceptance/user_creates_a_device_spec.rb
@@ -14,6 +14,6 @@ feature "User creates a new device when submitting a reading" do
     fill_in('Sensor', :with => 'LND-712')
 
     click_button('Save')
-    page.should have_content('LND-712')
+    expect(page).to have_content('LND-712')
   end
 end

--- a/spec/acceptance/user_creates_a_device_spec.rb
+++ b/spec/acceptance/user_creates_a_device_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "User creates a new device when submitting a reading" do
+feature "User creates a new device when submitting a reading", type: :feature do
   let(:user) { Fabricate(:user) }
 
   before { sign_in(user) }

--- a/spec/acceptance/user_profile_spec.rb
+++ b/spec/acceptance/user_profile_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "User Profile" do
+feature "User Profile", type: :feature do
   let(:user) { Fabricate(:user) }
   before { sign_in(user) }
 

--- a/spec/acceptance/user_profile_spec.rb
+++ b/spec/acceptance/user_profile_spec.rb
@@ -5,6 +5,6 @@ feature "User Profile" do
   before { sign_in(user) }
 
   scenario "viewing a user profile" do
-    page.should have_content(user.authentication_token)
+    expect(page).to have_content(user.authentication_token)
   end
 end

--- a/spec/acceptance/user_submits_reading_spec.rb
+++ b/spec/acceptance/user_submits_reading_spec.rb
@@ -13,11 +13,11 @@ feature "User submits a reading when a device does not exist" do
     fill_in('Radiation Level', :with => '123')
     fill_in('Location',        :with => 'Colwyn Bay, Wales')
     click_button('Submit')
-    page.should have_content('123')
-    page.should have_content('cpm')
-    user.should have(1).measurements
-    measurement.value.should == 123
-    measurement.location_name.should == 'Colwyn Bay, Wales'
+    expect(page).to have_content('123')
+    expect(page).to have_content('cpm')
+    expect(user.measurements.size).to eq(1)
+    expect(measurement.value).to eq(123)
+    expect(measurement.location_name).to eq('Colwyn Bay, Wales')
   end
 end
 
@@ -39,10 +39,10 @@ feature "User submits a reading while devices exist" do
     fill_in('Location',         :with => 'Los Angeles, CA')
     select('', :from => 'Device')
     click_button('Submit')
-    page.should have_content('456')
-    page.should have_content('cpm')
-    measurement.value.should == 456
-    measurement.device.should == nil
+    expect(page).to have_content('456')
+    expect(page).to have_content('cpm')
+    expect(measurement.value).to eq(456)
+    expect(measurement.device).to eq(nil)
   end
 
   scenario 'reading with a device' do
@@ -53,11 +53,11 @@ feature "User submits a reading while devices exist" do
     fill_in('Location',         :with => 'Tokyo, JP')
     select(device.name, :from => 'Device')
     click_button('Submit')
-    page.should have_content('789')
-    page.should have_content('cpm')
+    expect(page).to have_content('789')
+    expect(page).to have_content('cpm')
 
-    measurement.value.should == 789
-    measurement.device.should == device
+    expect(measurement.value).to eq(789)
+    expect(measurement.device).to eq(device)
 
   end
 end

--- a/spec/acceptance/user_submits_reading_spec.rb
+++ b/spec/acceptance/user_submits_reading_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "User submits a reading when a device does not exist" do
+feature "User submits a reading when a device does not exist", type: :feature do
   let(:user) { Fabricate(:user) }
   let(:measurement) { user.measurements.last }
 
@@ -21,7 +21,7 @@ feature "User submits a reading when a device does not exist" do
   end
 end
 
-feature "User submits a reading while devices exist" do
+feature "User submits a reading while devices exist", type: :feature do
   let(:user) { Fabricate(:user) }
   let(:measurement) { user.measurements.last }
   let(:device) { Fabricate(:device) }

--- a/spec/acceptance/user_uploads_bgeigie_log_spec.rb
+++ b/spec/acceptance/user_uploads_bgeigie_log_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "User uploads bgeigie log" do
+feature "User uploads bgeigie log", type: :feature do
   let!(:user) { Fabricate(:user) }
   let!(:moderator) { Fabricate(:user, :moderator => true) }
 

--- a/spec/acceptance/user_uploads_bgeigie_log_spec.rb
+++ b/spec/acceptance/user_uploads_bgeigie_log_spec.rb
@@ -12,16 +12,16 @@ feature "User uploads bgeigie log" do
       click_link('Upload a bGeigie log file')
       attach_file("File", Rails.root.join('spec', 'fixtures', 'bgeigie.log'))
       click_button("Upload")
-      page.should have_content('Unprocessed')
+      expect(page).to have_content('Unprocessed')
       fill_in 'Credits', :with => 'Bill'
       fill_in 'Cities', :with => 'Dublin'
       Delayed::Worker.new.work_off
       click_button 'Save'
-      page.should have_content('Processed')
+      expect(page).to have_content('Processed')
       click_button 'Submit for Approval'
-      page.should have_content('Submitted')
-      find_email(moderator.email, 
-        :with_subject => 'A Safecast import is awaiting approval').should be_present
+      expect(page).to have_content('Submitted')
+      expect(find_email(moderator.email, 
+        :with_subject => 'A Safecast import is awaiting approval')).to be_present
     end
   end
   
@@ -42,9 +42,9 @@ feature "User uploads bgeigie log" do
       click_button 'Approve'
       Delayed::Worker.new.work_off 
       visit(current_path)
-      page.should have_content('Processed')
-      find_email(user.email, 
-        :with_subject => 'Your Safecast import has been approved').should be_present
+      expect(page).to have_content('Processed')
+      expect(find_email(user.email, 
+        :with_subject => 'Your Safecast import has been approved')).to be_present
     end
   end
 end

--- a/spec/acceptance/user_views_bgeige_imports_spec.rb
+++ b/spec/acceptance/user_views_bgeige_imports_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "User views bGeigie imports" do
+feature "User views bGeigie imports", type: :feature do
   let!(:user) { Fabricate(:user) }
   let!(:bgeigie_import) { Fabricate(:bgeigie_import, :user => user, :name => 'my import', :status => "done") }
 

--- a/spec/acceptance/user_views_bgeige_imports_spec.rb
+++ b/spec/acceptance/user_views_bgeige_imports_spec.rb
@@ -8,7 +8,7 @@ feature "User views bGeigie imports" do
     sign_in(user)
     visit('/')
     click_link("Imports")
-    page.should have_content("bgeigie0.log")
+    expect(page).to have_content("bgeigie0.log")
   end
 
 

--- a/spec/acceptance/user_views_their_measurements_spec.rb
+++ b/spec/acceptance/user_views_their_measurements_spec.rb
@@ -9,13 +9,13 @@ feature "User submits a reading" do
   scenario "First reading" do
     visit("/")
     click_link("Submissions")
-    page.should have_content("10101")
+    expect(page).to have_content("10101")
   end
 
   scenario "Viewing a single measurement entry" do
     measurement.captured_at = nil
     measurement.save
     visit("/en-US/measurements/#{measurement.id}")
-    find(".dl-horizontal > dd:nth-child(4)").should have_text("null")
+    expect(find(".dl-horizontal > dd:nth-child(4)")).to have_text("null")
   end
 end

--- a/spec/acceptance/user_views_their_measurements_spec.rb
+++ b/spec/acceptance/user_views_their_measurements_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "User submits a reading" do
+feature "User submits a reading", type: :feature do
   let!(:user) { Fabricate(:user) }
   let!(:measurement) { Fabricate(:measurement, :user => user, :value => 10101) }
   

--- a/spec/controllers/bgeigie_logs_controller_spec.rb
+++ b/spec/controllers/bgeigie_logs_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe BgeigieLogsController do
-
-end

--- a/spec/controllers/bgeigie_logs_controller_spec.rb
+++ b/spec/controllers/bgeigie_logs_controller_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe BgeigieLogsController, type: :controller do
+  let!(:bgeigie_import) { Fabricate(:bgeigie_import) }
+
+  describe 'GET #index', format: :json do
+    before do
+      get :index, bgeigie_import_id: bgeigie_import.id, format: :json
+    end
+
+    it { expect(response).to be_ok }
+  end
+end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -59,3 +59,22 @@ RSpec.describe RailsAdmin::MainController, 'login as admin', type: :controller d
     it { expect(response).to be_ok }
   end
 end
+
+RSpec.describe RailsAdmin::MainController, 'login as user', type: :controller do
+  before do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+
+    sign_in Fabricate(:user)
+  end
+
+  let!(:bgeigie_log) { BgeigieLog.create }
+  let(:model_name) { 'bgeigie_log' }
+
+  describe 'GET #dashboard' do
+    before do
+      get :dashboard
+    end
+
+    it { expect(response).to redirect_to('/en-US') }
+  end
+end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 # XXX: Currently, this spec is for checking rails_admin gem installation.
-RSpec.describe RailsAdmin::MainController, 'login as admin' do
+RSpec.describe RailsAdmin::MainController, 'login as admin', type: :controller do
   before do
     @request.env['devise.mapping'] = Devise.mappings[:user]
 

--- a/spec/helpers/measurements_helper_spec.rb
+++ b/spec/helpers/measurements_helper_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe MeasurementsHelper, type: :helper do
+  describe '#measurement_nav_li' do
+    before do
+      allow(helper).to receive(:[]).with(:unit).and_return('all')
+    end
+
+
+    it 'should have li tag with "active" class attribute' do
+      doc = Nokogiri.HTML(helper.measurement_nav_li(:all))
+
+      expect(doc.xpath("//li[@class='active']")).to be_present
+    end
+  end
+end

--- a/spec/integration/api/bgeigie_imports_spec.rb
+++ b/spec/integration/api/bgeigie_imports_spec.rb
@@ -18,9 +18,9 @@ feature "/bgeigie_imports API endpoint" do
   
   context "just an upload" do
     scenario "response should be unprocessed" do
-      @result['id'].should_not be_blank
-      @result['status'].should == 'unprocessed'
-      @result['md5sum'].should == 'aad36f9743753b490745c9656cd8fc79'
+      expect(@result['id']).not_to be_blank
+      expect(@result['status']).to eq('unprocessed')
+      expect(@result['md5sum']).to eq('aad36f9743753b490745c9656cd8fc79')
     end
   end
   
@@ -38,11 +38,11 @@ feature "/bgeigie_imports API endpoint" do
     subject { updated_result }
 
     scenario "response should be processed" do      
-      updated_result['status'].should == 'done'
+      expect(updated_result['status']).to eq('done')
     end
     
     scenario "it should have imported a bunch of measurements" do
-      updated_result['measurements_count'].should == 23
+      expect(updated_result['measurements_count']).to eq(23)
     end
   end
 end

--- a/spec/integration/api/bgeigie_imports_spec.rb
+++ b/spec/integration/api/bgeigie_imports_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "/bgeigie_imports API endpoint" do
+feature "/bgeigie_imports API endpoint", type: :feature do
 
   before(:each) do
     User.destroy_all

--- a/spec/integration/api/devices_spec.rb
+++ b/spec/integration/api/devices_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "/devices API endpoint" do
+feature "/devices API endpoint", type: :feature do
 
   before do
     @user = Fabricate(:user, :email => 'paul@rslw.com', :name => 'Paul Campbell')
@@ -48,7 +48,7 @@ feature "/devices API endpoint" do
   
 end
 
-feature "/devices with existing devices" do
+feature "/devices with existing devices", type: :feature do
   
   before do
     @user = Fabricate(:user, :email => 'paul@rslw.com', :name => 'Paul Campbell')

--- a/spec/integration/api/devices_spec.rb
+++ b/spec/integration/api/devices_spec.rb
@@ -22,12 +22,12 @@ feature "/devices API endpoint" do
       }
     )
     result = ActiveSupport::JSON.decode(response.body)
-    result['manufacturer'].should == 'Safecast'
-    result['model'].should == 'bGeigie'
-    result['sensor'].should == 'LND-7317'
+    expect(result['manufacturer']).to eq('Safecast')
+    expect(result['model']).to eq('bGeigie')
+    expect(result['sensor']).to eq('LND-7317')
     
     idCreated = result.include?('id')
-    idCreated.should == true
+    expect(idCreated).to eq(true)
   end
   
   scenario "empty post" do
@@ -41,9 +41,9 @@ feature "/devices API endpoint" do
     )
     
     result = ActiveSupport::JSON.decode(response.body)
-    result['errors']['manufacturer'].should be_present
-    result['errors']['model'].should be_present
-    result['errors']['sensor'].should be_present
+    expect(result['errors']['manufacturer']).to be_present
+    expect(result['errors']['model']).to be_present
+    expect(result['errors']['sensor']).to be_present
   end
   
 end
@@ -90,15 +90,15 @@ feature "/devices with existing devices" do
       }  
     )
     result = ActiveSupport::JSON.decode(response.body)
-    result['id'].should == first_device.id
+    expect(result['id']).to eq(first_device.id)
   end
   
   scenario "lookup all devices" do
     result = api_get('/devices', {}, {'HTTP_ACCEPT' => 'application/json'})
-    result.length.should == 3
-    result.map { |obj| obj['manufacturer'] }.should == ['Safecast', 'Medcom', 'Safecast']
-    result.map { |obj| obj['model'] }.should == ['bGeigie', 'Inspector', 'iGeigie']
-    result.map { |obj| obj['sensor'] }.should == ['LND-7317', 'LND-712', 'LND-712']
+    expect(result.length).to eq(3)
+    expect(result.map { |obj| obj['manufacturer'] }).to eq(['Safecast', 'Medcom', 'Safecast'])
+    expect(result.map { |obj| obj['model'] }).to eq(['bGeigie', 'Inspector', 'iGeigie'])
+    expect(result.map { |obj| obj['sensor'] }).to eq(['LND-7317', 'LND-712', 'LND-712'])
   end
   
   scenario "lookup all Safecast devices" do
@@ -110,10 +110,10 @@ feature "/devices with existing devices" do
         'HTTP_ACCEPT' => 'application/json'
       }
     )
-    result.length.should == 2
-    result.map { |obj| obj['manufacturer'] }.should == ['Safecast', 'Safecast']
-    result.map { |obj| obj['model'] }.should == ['bGeigie', 'iGeigie']
-    result.map { |obj| obj['sensor'] }.should == ['LND-7317', 'LND-712']
+    expect(result.length).to eq(2)
+    expect(result.map { |obj| obj['manufacturer'] }).to eq(['Safecast', 'Safecast'])
+    expect(result.map { |obj| obj['model'] }).to eq(['bGeigie', 'iGeigie'])
+    expect(result.map { |obj| obj['sensor'] }).to eq(['LND-7317', 'LND-712'])
   end
   
   scenario "lookup a particular device" do
@@ -125,10 +125,10 @@ feature "/devices with existing devices" do
         'HTTP_ACCEPT' => 'application/json'
       }
     )
-    result.length.should == 1
-    result.first['manufacturer'].should == "Safecast"
-    result.first['model'].should == "iGeigie"
-    result.first['sensor'].should == "LND-712"
+    expect(result.length).to eq(1)
+    expect(result.first['manufacturer']).to eq("Safecast")
+    expect(result.first['model']).to eq("iGeigie")
+    expect(result.first['sensor']).to eq("LND-712")
   end
   
 end

--- a/spec/integration/api/measurements_spec.rb
+++ b/spec/integration/api/measurements_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "/measurements API endpoint" do
+feature "/measurements API endpoint", type: :feature do
 
   let!(:user) do
     User.first || Fabricate(:user,
@@ -28,7 +28,7 @@ feature "/measurements API endpoint" do
   end
 end
 
-feature "/measurements" do
+feature "/measurements", type: :feature do
   
   before(:all) { Measurement.destroy_all }
 

--- a/spec/integration/api/measurements_spec.rb
+++ b/spec/integration/api/measurements_spec.rb
@@ -18,13 +18,13 @@ feature "/measurements API endpoint" do
         :longitude  => 2.2
       }
     })
-    result['value'].should == 123
-    result['user_id'].should == user.id
+    expect(result['value']).to eq(123)
+    expect(result['user_id']).to eq(user.id)
   end
   
   scenario "empty post" do
     result = api_post('/measurements.json',{ :api_key => user.authentication_token })
-    result['errors']['value'].should be_present
+    expect(result['errors']['value']).to be_present
   end
 end
 
@@ -40,20 +40,20 @@ feature "/measurements" do
   
   scenario "all measurements (/measurements)" do
     result = api_get("/measurements.json")
-    result.length.should == 2
-    result.map { |obj| obj['value'] }.should == [10, 12]
+    expect(result.length).to eq(2)
+    expect(result.map { |obj| obj['value'] }).to eq([10, 12])
   end
 
   scenario "get measurement count (/measurements/count)" do
     result = api_get('/measurements/count.json')
-    result.length.should == 1
-    result['count'].should == 2
+    expect(result.length).to eq(1)
+    expect(result['count']).to eq(2)
   end
   
   scenario "get my measurements (/users/X/measurements)" do
     result = api_get("/measurements.json?user_id=#{user.id}")
-    result.length.should == 1
-    result.first['value'].should == 12
+    expect(result.length).to eq(1)
+    expect(result.first['value']).to eq(12)
   end
   
   scenario "updating is non-destructive" do
@@ -66,20 +66,20 @@ feature "/measurements" do
     
     result = ActiveSupport::JSON.decode(response.body)
     
-    result['value'].should == 15
-    result['original_id'].should == second_measurement.id
+    expect(result['value']).to eq(15)
+    expect(result['original_id']).to eq(second_measurement.id)
 
     
     #the above is pretty normal, now we do some gets to check that it was non-destructive
     result = api_get("/measurements.json?original_id=#{second_measurement.id}")
-    result.length.should == 2
+    expect(result.length).to eq(2)
     result.sort_by! { |obj| obj['value']}
-    result.map { |obj| obj['value'] }.should == [12, 15]
+    expect(result.map { |obj| obj['value'] }).to eq([12, 15])
     
     
     #withHistory defaults to false, returns latest value
     result = api_get("/measurements/#{second_measurement.id}.json")
-    result['value'].should == 12
+    expect(result['value']).to eq(12)
   end
 
   scenario "get new measurements since some time" do
@@ -100,10 +100,10 @@ feature "/measurements" do
       :since => cutoff_time
     })
 
-    result.length.should == 1
-    result.first['value'].should == 4342
-    result.first['latitude'].should == 76.667
-    result.first['longitude'].should == 33.321
+    expect(result.length).to eq(1)
+    expect(result.first['value']).to eq(4342)
+    expect(result.first['latitude']).to eq(76.667)
+    expect(result.first['longitude']).to eq(33.321)
   end
   
 end

--- a/spec/integration/api/users_spec.rb
+++ b/spec/integration/api/users_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "/api/users API endpoint" do
+feature "/api/users API endpoint", type: :feature do
 
   before(:all) { User.destroy_all }
   before do

--- a/spec/integration/api/users_spec.rb
+++ b/spec/integration/api/users_spec.rb
@@ -14,10 +14,10 @@ feature "/api/users API endpoint" do
       :password => 'testing123'
     })
     result = ActiveSupport::JSON.decode(response.body)
-    result['email'].should == 'kevin@rkn.la'
-    result['id'].should_not == nil
+    expect(result['email']).to eq('kevin@rkn.la')
+    expect(result['id']).not_to eq(nil)
     hasAuth = result.include?('authentication_token')
-    hasAuth.should == true
+    expect(hasAuth).to eq(true)
   end
   
 end

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Notifications do
+RSpec.describe Notifications, type: :mailer do
   # describe "import_approved" do
   #   let(:mail) { Notifications.import_approved }
 

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,4 +1,0 @@
-require "spec_helper"
-
-describe Admin do
-end

--- a/spec/models/bgeigie_import_spec.rb
+++ b/spec/models/bgeigie_import_spec.rb
@@ -18,30 +18,30 @@ describe BgeigieImport do
     end
 
     it "should create 23 Bgeigie Logs" do
-      BgeigieLog.count.should == 23
+      expect(BgeigieLog.count).to eq(23)
     end
 
     it "should count the number of lines in the file" do
-      bgeigie_import.lines_count.should == 23
+      expect(bgeigie_import.lines_count).to eq(23)
     end
     
     it "should set the id" do
-      BgeigieLog.all.collect { |bl| bl.bgeigie_import_id }.uniq.should == [bgeigie_import.id]
+      expect(BgeigieLog.all.collect { |bl| bl.bgeigie_import_id }.uniq).to eq([bgeigie_import.id])
     end
     
     it "should create measurements" do
-      Measurement.count.should == 23
+      expect(Measurement.count).to eq(23)
     end
     
     it "should not load them twice" do
       bgeigie_import.process
-      Measurement.count.should == 23
+      expect(Measurement.count).to eq(23)
     end
     
     it "should set measurement attributes" do
       measurement = Measurement.find_by_md5sum('6750a7cf2a630c2dde416dc7d138fa74')
-      measurement.location.should_not be_blank
-      measurement.captured_at.should_not be_blank
+      expect(measurement.location).not_to be_blank
+      expect(measurement.captured_at).not_to be_blank
     end
 
     it "should calculate measurements to the correct hemisphere" do
@@ -54,8 +54,8 @@ describe BgeigieImport do
 
       measurement = Measurement.find_by_md5sum('c435ff4da6a7a16e92282bd10381b6d7')
 
-      measurement.location.x.should == -73.92277166666666
-      measurement.location.y.should == 41.698078333333335
+      expect(measurement.location.x).to eq(-73.92277166666666)
+      expect(measurement.location.y).to eq(41.698078333333335)
     end
 
 
@@ -69,8 +69,8 @@ describe BgeigieImport do
 
       measurement = Measurement.find_by_md5sum('97badba59dda4a56958fc40b16277db4')
 
-      measurement.location.x.should == -73.92259666666666
-      measurement.location.y.should == 41.69836166666666
+      expect(measurement.location.x).to eq(-73.92259666666666)
+      expect(measurement.location.y).to eq(41.69836166666666)
     end
 
     it "should handle files with corrupt or incomplete lines" do
@@ -81,7 +81,7 @@ describe BgeigieImport do
       bgeigie_with_bugs.process
       bgeigie_with_bugs.finalize!
 
-      Measurement.all.count.should == 30 #the before :each import has 23, and the corrupted file should have 7 valid measurements
+      expect(Measurement.all.count).to eq(30) #the before :each import has 23, and the corrupted file should have 7 valid measurements
 
     end
     

--- a/spec/models/bgeigie_import_spec.rb
+++ b/spec/models/bgeigie_import_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe BgeigieImport do
+RSpec.describe BgeigieImport, type: :model do
   
   let!(:user) { User.first || Fabricate(:user) }
   

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Device do
+RSpec.describe Device, type: :model do
   let(:device) { Fabricate(:device, {
     :manufacturer     => 'Safecast',
     :model            => 'iGeigie',

--- a/spec/models/drive_import_spec.rb
+++ b/spec/models/drive_import_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe DriveImport, type: :model do
+  let!(:user) { User.where(id: 1).first || Fabricate(:user, id: 1) }
+
+  let(:drive_import_source) do
+    f = Tempfile.new('drive_import_source')
+    f.write('123')
+    f.rewind
+    Rack::Test::UploadedFile.new(f.path, 'text/plain')
+  end
+
+  let(:drive_import_params_base) do
+    { source: drive_import_source, description: 'Test' }
+  end
+
+  let(:drive_import) { described_class.create(drive_import_params) }
+
+  describe '#name' do
+    subject { drive_import.name }
+
+    context 'when it has name' do
+      let(:drive_import_params) { drive_import_params_base.merge(name: 'MyDrive') }
+
+      it { is_expected.to eq('MyDrive') }
+    end
+
+    context 'when it has no name' do
+      let(:drive_import_params) { drive_import_params_base }
+
+      it { is_expected.to eq("Drive ##{drive_import.id}") }
+    end
+  end
+
+  describe '#process' do
+    let(:drive_import_params) { drive_import_params_base }
+
+    before { drive_import.process }
+
+    it { expect(drive_import.map).to be_present }
+    it { expect(drive_import.status).to eq('done') }
+  end
+
+  describe '#user' do
+    let(:drive_import_params) { drive_import_params_base }
+
+    subject { drive_import.user }
+
+    it { is_expected.to eq(user) }
+  end
+
+  describe '#user_id' do
+    let(:drive_import_params) { drive_import_params_base }
+
+    subject { drive_import.user_id }
+
+    it { is_expected.to eq(1) }
+  end
+end

--- a/spec/models/drive_log_spec.rb
+++ b/spec/models/drive_log_spec.rb
@@ -1,4 +1,0 @@
-require "spec_helper"
-
-describe DriveLog do
-end

--- a/spec/models/drive_log_spec.rb
+++ b/spec/models/drive_log_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe DriveLog, type: :model do
+  let(:drive_log) { described_class.create }
+
+  describe '#update_md5sum' do
+    before { drive_log.update_md5sum }
+
+    subject { drive_log.md5sum }
+
+    it { is_expected.to be_present }
+  end
+
+  describe '#update_location' do
+    # FIXME: uninitialized constant DriveLog::Point
+    it { expect { drive_log.update_location }.to raise_exception(NameError) }
+  end
+end

--- a/spec/models/measurement_spec.rb
+++ b/spec/models/measurement_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Measurement do
+RSpec.describe Measurement, type: :model do
   context "setting location" do
     let(:measurement) { Fabricate(:measurement, {
       :location => 'POINT(12.001 14.002)'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe User do
+RSpec.describe User, type: :model do
   let(:user) { Fabricate.build(:user, :name => "Paul Campbell")}
   
   describe "#first_name and #last_name" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,4 +70,15 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
This PR is related to #170. To update rails, I would like to have more coverages (~90%), so I added more specs and removed seems-to-be-unused code. Also, I updated rspec to 2.99.x.

~~I would like to review by someone who have more experience. Especially, these commits:~~

* ~~https://github.com/Safecast/safecastapi/commit/17f143319c806961ab9c9f2127fbf5d37ad77ec0~~
* ~~https://github.com/Safecast/safecastapi/commit/6cc345317647959e6c105a72c011940a2d2b1130~~

I removed methods that seem to be unused.

Also, I wrote specs for `DriveImport` and `DriveLog` models, but they seem to used for data migration purpose and not used now. Can I delete these models?

* https://github.com/Safecast/safecastapi/commit/1c8c66e8190a0b46340150ad20aa94acc902990b
* https://github.com/Safecast/safecastapi/commit/86f49f6d1a7ab3db03555f63efd8dad59d7e1a3d

