### PR TITLE
Refactor Carrierwave initialization file

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,18 +1,16 @@
-if Rails.env.test? or Rails.env.cucumber?
-  CarrierWave.configure do |config|
+CarrierWave.configure do |config|
+  if Rails.env.test?
     config.storage = :file
     config.enable_processing = false
   end
-else
-  CarrierWave.configure do |config|
-    config.fog_credentials = {
-      :provider               => 'AWS',       # required
-      :aws_access_key_id      => Configurable.aws_access_key_id,       # required
-      :aws_secret_access_key  => Configurable.aws_secret_access_key,       # required
-      :region                 => 'us-east-1'  # optional, defaults to 'us-east-1'
-    }
-    config.fog_directory  = Configurable.s3_bucket                     # required
-    config.fog_public     = true                                   # optional, defaults to true
-    config.fog_attributes = {'Cache-Control'=>'max-age=315576000'}  # optional, defaults to {}
-  end
+
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: Configurable.aws_access_key_id,
+    aws_secret_access_key: Configurable.aws_secret_access_key,
+    region: 'us-east-1'
+  }
+  config.fog_directory = Configurable.s3_bucket
+  config.fog_public = true
+  config.fog_attributes = { 'Cache-Control' => 'max-age=315576000' }
 end


### PR DESCRIPTION
`FileUploader` (app/uploader/file_uploader.rb) configures which storage to use. This file just configures Carrierwave. For test coverage purpose, it would be nice to configure even in test environment.

<img width="658" alt="config_initializers_carrierwave_rb_coverage_from_safecast_safecastapi_-_code_climate" src="https://cloud.githubusercontent.com/assets/34205/15806323/b8fc0642-2b7b-11e6-8300-7f509c8fd07b.png">
