### PR TITLE
Fix issue 271

### DIFF
--- a/app/models/measurement_import.rb
+++ b/app/models/measurement_import.rb
@@ -11,9 +11,12 @@ class MeasurementImport < ActiveRecord::Base
   before_validation :set_md5sum, :on => :create
   after_initialize :set_default_values
 
+  AVAILABLE_SUBTYPES = %w(None Drive Surface Cosmic).freeze
+
   def set_default_values
     self.status ||= 'unprocessed'
-    self.subtype ||= 'None'
+    self.subtype =
+      AVAILABLE_SUBTYPES[0] unless AVAILABLE_SUBTYPES.include?(subtype)
   end
 
   def set_md5sum

--- a/app/models/measurement_import.rb
+++ b/app/models/measurement_import.rb
@@ -9,12 +9,13 @@ class MeasurementImport < ActiveRecord::Base
   mount_uploader :source, FileUploader
 
   before_validation :set_md5sum, :on => :create
-  after_initialize :set_status
+  after_initialize :set_default_values
 
-  def set_status
+  def set_default_values
     self.status ||= 'unprocessed'
-  end 
-  
+    self.subtype ||= 'None'
+  end
+
   def set_md5sum
     self.md5sum = Digest::MD5.hexdigest(source.read)
   end

--- a/db/migrate/20160607005457_alter_measurement_imports_subtype_set_not_null.rb
+++ b/db/migrate/20160607005457_alter_measurement_imports_subtype_set_not_null.rb
@@ -1,0 +1,13 @@
+class AlterMeasurementImportsSubtypeSetNotNull < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER TABLE measurement_imports ALTER COLUMN subtype SET NOT NULL;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE measurement_imports ALTER COLUMN subtype DROP NOT NULL;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -415,7 +415,7 @@ CREATE TABLE measurement_imports (
     orientation character varying(255),
     cities text,
     comment character varying(255),
-    subtype measurement_imports_subtype DEFAULT 'None'::measurement_imports_subtype
+    subtype measurement_imports_subtype DEFAULT 'None'::measurement_imports_subtype NOT NULL
 );
 
 

--- a/spec/controllers/bgeigie_imports_controller_spec.rb
+++ b/spec/controllers/bgeigie_imports_controller_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe BgeigieImportsController, type: :controller do
+  let(:user) { Fabricate(:user) }
+  describe 'POST #create', format: :json do
+    let(:bgeigie_import_params) do
+      {
+        source: fixture_file_upload('/bgeigie.log'),
+        cities: 'Tokyo',
+        credits: 'John Doe'
+      }
+    end
+
+    before do
+      sign_in user
+
+      post :create, { format: :json }.merge(post_params)
+    end
+
+    context 'without subtype' do
+      let(:post_params) { { bgeigie_import: bgeigie_import_params } }
+
+      it { expect(response.status).to eq(201) }
+      it { expect(assigns(:bgeigie_import)).to be_persisted }
+      it 'should set subtype of import to "None"' do
+        expect(assigns(:bgeigie_import).subtype).to eq('None')
+      end
+    end
+
+    context 'with subtype "Drive"' do
+      let(:post_params) do
+        { bgeigie_import: bgeigie_import_params.merge(subtype: 'Drive') }
+      end
+
+      it { expect(response.status).to eq(201) }
+      it { expect(assigns(:bgeigie_import)).to be_persisted }
+      it 'should set subtype of import to "None"' do
+        expect(assigns(:bgeigie_import).subtype).to eq('Drive')
+      end
+    end
+  end
+end

--- a/spec/controllers/bgeigie_imports_controller_spec.rb
+++ b/spec/controllers/bgeigie_imports_controller_spec.rb
@@ -36,5 +36,17 @@ RSpec.describe BgeigieImportsController, type: :controller do
         expect(assigns(:bgeigie_import).subtype).to eq('Drive')
       end
     end
+
+    context 'with empty subtype' do
+      let(:post_params) do
+        { bgeigie_import: bgeigie_import_params.merge(subtype: '') }
+      end
+
+      it { expect(response.status).to eq(201) }
+      it { expect(assigns(:bgeigie_import)).to be_persisted }
+      it 'should set subtype of import to "None"' do
+        expect(assigns(:bgeigie_import).subtype).to eq('None')
+      end
+    end
   end
 end

--- a/spec/models/bgeigie_import_spec.rb
+++ b/spec/models/bgeigie_import_spec.rb
@@ -1,16 +1,13 @@
-require 'spec_helper'
-
 RSpec.describe BgeigieImport, type: :model do
-  
-  let!(:user) { User.first || Fabricate(:user) }
-  
+  let(:user) { Fabricate(:user) }
+
   let!(:bgeigie_import) do
     Fabricate(:bgeigie_import,
               :source => File.new(Rails.root.join('spec/fixtures/bgeigie.log')),
               :user_id => user.id
              )
   end
-  
+
   describe "#process" do
     before(:each) do
       bgeigie_import.process
@@ -24,20 +21,20 @@ RSpec.describe BgeigieImport, type: :model do
     it "should count the number of lines in the file" do
       expect(bgeigie_import.lines_count).to eq(23)
     end
-    
+
     it "should set the id" do
       expect(BgeigieLog.all.collect { |bl| bl.bgeigie_import_id }.uniq).to eq([bgeigie_import.id])
     end
-    
+
     it "should create measurements" do
       expect(Measurement.count).to eq(23)
     end
-    
+
     it "should not load them twice" do
       bgeigie_import.process
       expect(Measurement.count).to eq(23)
     end
-    
+
     it "should set measurement attributes" do
       measurement = Measurement.find_by_md5sum('6750a7cf2a630c2dde416dc7d138fa74')
       expect(measurement.location).not_to be_blank
@@ -57,7 +54,6 @@ RSpec.describe BgeigieImport, type: :model do
       expect(measurement.location.x).to eq(-73.92277166666666)
       expect(measurement.location.y).to eq(41.698078333333335)
     end
-
 
     it "should calculate measurements to the correct hemisphere" do
       bgeigie_with_bugs = Fabricate(:bgeigie_import,
@@ -82,10 +78,6 @@ RSpec.describe BgeigieImport, type: :model do
       bgeigie_with_bugs.finalize!
 
       expect(Measurement.all.count).to eq(30) #the before :each import has 23, and the corrupted file should have 7 valid measurements
-
     end
-    
   end
-  
-  after(:each) { BgeigieLog.destroy_all }
 end

--- a/spec/models/bgeigie_import_spec.rb
+++ b/spec/models/bgeigie_import_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe BgeigieImport, type: :model do
              )
   end
 
+  describe '#initialize' do
+    it 'should set subtype to "None" by default' do
+      expect(described_class.new.subtype).to eq('None')
+    end
+
+    it 'should use provided subtype' do
+      expect(described_class.new(subtype: 'Drive').subtype)
+        .to eq('Drive')
+    end
+  end
+
   describe "#process" do
     before(:each) do
       bgeigie_import.process


### PR DESCRIPTION
This PR should fix #271 

When a `MeasurementImport` is created via `ActiveRecord`, AR seems to set unspecified columns to `NULL` (`nil`) explicitly, so I set subtype to 'None' when creating `MeasurementImport`.

This is `rails console` session in current master to show AR set `NULL` to unspecified columns.
```
[1] pry(main)> bi = BgeigieImport.create(cities: 'Tokyo', credits: 'John', source: File.open('spec/fixtures/bgeigie.log'), user_id: 1)
   (1.6ms)  SELECT * FROM geometry_columns WHERE f_table_name='measurement_imports'
   (0.1ms)  BEGIN
  MeasurementImport Exists (0.9ms)  SELECT 1 AS one FROM "measurement_imports" W
HERE "measurement_imports"."md5sum" = 'aad36f9743753b490745c9656cd8fc79' LIMIT 1
   (1.4ms)  SELECT * FROM geometry_columns WHERE f_table_name='users'
  User Load (0.5ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1
  SQL (2.3ms)  INSERT INTO "measurement_imports" ("approved", "cities", "comment", "created_at", "credits", "description", "height", "lines_count", "map_id", "md5sum", "measurements_count", "name", "orientation", "source", "status", "status
_details", "subtype", "type", "updated_at", "user_id") VALUES ($1, $2, $3, $4, $
5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) RETURNING "id"  [["approved", false], ["cities", "Tokyo"], ["comment", nil], ["created_at", Tue, 07 Jun 2016 01:43:35 UTC +00:00], ["credits", "John"], ["description"
, nil], ["height", nil], ["lines_count", nil], ["map_id", nil], ["md5sum", "aad36f9743753b490745c9656cd8fc79"], ["measurements_count", nil], ["name", nil], ["orientation", nil], ["source", "bgeigie.log"], ["status", "unprocessed"], ["status_details", nil], ["subtype", nil], ["type", "BgeigieImport"], ["updated_at", Tue, 07 Jun 2016 01:43:35 UTC +00:00], ["user_id", 1]]
   (6.1ms)  COMMIT
=> #<BgeigieImport id: 2, user_id: 1, source: "bgeigie.log", md5sum: "aad36f9743
753b490745c9656cd8fc79", type: "BgeigieImport", status: "unprocessed", measureme
nts_count: nil, map_id: nil, status_details: {}, approved: false, created_at: "2
016-06-07 01:43:35", updated_at: "2016-06-07 01:43:35", name: nil, description:
nil, lines_count: nil, credits: "John", height: nil, orientation: nil, cities: "
Tokyo", comment: nil, subtype: nil>
[2] pry(main)> MeasurementImport.all
  MeasurementImport Load (0.3ms)  SELECT "measurement_imports".* FROM "measurement_imports"
=> [#<BgeigieImport id: 2, user_id: 1, source: "bgeigie.log", md5sum: "aad36f9743753b490745c9656cd8fc79", type: "BgeigieImport", status: "unprocessed", measurements_count: nil, map_id: nil, status_details: {}, approved: false, created_at: "2016-06-07 01:43:35", updated_at: "2016-06-07 01:43:35", name: nil, description: nil, lines_count: nil, credits: "John", height: nil, orientation: nil, cities: "Tokyo", comment: nil, subtype: nil>]
[3] pry(main)> ActiveRecord::Base.connection.execute('SELECT * from measurement_imports').each { |tuple| p tuple }
   (0.3ms)  SELECT * from measurement_imports
{"id"=>"2", "user_id"=>"1", "source"=>"bgeigie.log", "md5sum"=>"aad36f9743753b490745c9656cd8fc79", "type"=>"BgeigieImport", "status"=>"unprocessed", "measurements_count"=>nil, "map_id"=>nil, "status_details"=>nil, "approved"=>"f", "created_at"=>"2016-06-07 01:43:35.752086", "updated_at"=>"2016-06-07 01:43:35.752086", "name"=>nil, "description"=>nil, "lines_count"=>nil, "credits"=>"John", "height"=>nil, "orientation"=>nil, "cities"=>"Tokyo", "comment"=>nil, "subtype"=>nil}
=> #<PG::Result:0x007fa2a1d3ee88 @connection=#<PG::Connection:0x007fa2a1a24158>>
```