### PR TITLE
Change BgeigieImportsController#destroy so that only owner or moderator can delete bgeigie import

### DIFF
--- a/app/controllers/bgeigie_imports_controller.rb
+++ b/app/controllers/bgeigie_imports_controller.rb
@@ -87,9 +87,12 @@ class BgeigieImportsController < ApplicationController
   end
 
   def destroy
-    @bgeigie_import = BgeigieImport.where(:id => params[:id]).first
-    @bgeigie_import.destroy if @bgeigie_import.present?
-    redirect_to :bgeigie_imports
+    bgeigie_import = scope.where(id: params[:id]).first
+    if bgeigie_import && bgeigie_import.destroy
+      redirect_to :bgeigie_imports
+    else
+      render text: '404 Not Found', status: :not_found
+    end
   end
 
 private

--- a/spec/controllers/bgeigie_imports_controller_spec.rb
+++ b/spec/controllers/bgeigie_imports_controller_spec.rb
@@ -91,4 +91,52 @@ RSpec.describe BgeigieImportsController, type: :controller do
       end
     end
   end
+
+  describe 'DELETE #destroy', format: :html do
+    let(:bgeigie_import) { Fabricate(:bgeigie_import, user: user, cities: 'Tokyo', credits: 'John Doe') }
+
+    before do
+      sign_in login_user if login_user
+
+      delete :destroy, id: bgeigie_import.id
+    end
+
+    context 'when login user is owner of bgeigie import' do
+      let(:login_user) { user }
+
+      it { expect(response).to redirect_to(bgeigie_imports_path) }
+      it 'should delete bgeigie import' do
+        expect { BgeigieImport.find(bgeigie_import.id) }
+          .to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when login user is not owner of bgeigie import' do
+      let(:login_user) { Fabricate(:user) }
+
+      it { expect(response).to be_not_found }
+      it 'should not delete bgeigie import' do
+        expect { BgeigieImport.find(bgeigie_import.id) }.to_not raise_error
+      end
+    end
+
+    context 'when login user is not owner of bgeigie import, but moderator' do
+      let(:login_user) { Fabricate(:user, moderator: true) }
+
+      it { expect(response).to redirect_to(bgeigie_imports_path) }
+      it 'should delete bgeigie import' do
+        expect { BgeigieImport.find(bgeigie_import.id) }
+          .to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when non-login user' do
+      let(:login_user) { nil }
+
+      it { expect(response) .to redirect_to(new_user_session_path(locale: request.params[:locale])) }
+      it 'should not delete bgeigie import' do
+        expect { BgeigieImport.find(bgeigie_import.id) }.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, any login user can delete any bgeigie imports. Is this expected behavior? I thought that user can delete her/his imports and moderator can delete any imports, so I made this PR.