### PR TITLE
Fix to wrap some measurement parameters in rails 4

### DIFF
--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -1,4 +1,16 @@
 class MeasurementsController < ApplicationController
+  class << self
+    def attribute_names_to_be_wrapped
+      names = Measurement.attribute_names
+      names -= %w(id created_at updated_at)
+      names += %w(latitude longitude)
+      names
+    end
+  end
+
+  # Need this to wrap longitude and latitude even we enable in
+  # config/initializers/wrap_parameters.rb
+  wrap_parameters include: attribute_names_to_be_wrapped, format: %i(json)
 
   before_filter :authenticate_user!, :only => [:new, :create, :update, :destroy]
 

--- a/spec/controllers/measurements_controller_spec.rb
+++ b/spec/controllers/measurements_controller_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe MeasurementsController, type: :controller do
     end
   end
 
+  describe 'POST #create', format: :json, from: 'API-Gateway' do
+    # https://github.com/Safecast/API-Gateways posts measurement
+    # JSON data in this way.
+    context 'valid data without measurement prefix' do
+      let(:post_params) { valid_data }
+
+      before do
+        request.headers['Content-Type'] = 'application/json'
+
+        post :create, { api_key: api_key, format: :json }.merge(post_params)
+      end
+
+      it { expect(response.status).to eq(201) }
+      it { expect(user.reload.measurements.count).to eq(1) }
+    end
+  end
+
   describe 'GET #new' do
     before do
       sign_in user


### PR DESCRIPTION
API-Gateway posts JSON data like `{"longitude":"-70.872505","latitude":"42.812292","device_id":"99","value":"34","unit":"cpm","captured_at":"2016-06-20T13:14:00Z"}`. After updating to Rails 4, some parameters like `longitude` and `latitude` were not wrapped like `{ "measurement" : { "device_id":"99","value":"34","unit":"cpm","captured_at":"2016-06-20T13:14:00Z"}`. And this causes errors.

In `config/initializers/wrap_parameters.rb`, it is configured to wrap parameters if request is in JSON.

This PR change to define parameter names explicitly in `MeasurementsController`.