### PR TITLE
Fix condition for force_ssl and enable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   force_ssl if: :ssl_enabled?
 
+  before_filter :strict_transport_security
   before_filter :set_locale
   before_filter :configure_permitted_parameters, if: :devise_controller?
   before_filter :cors_set_access_control_headers
@@ -81,8 +82,9 @@ protected
     end
   end
 
+  # API-Gateway needs to send in HTTP
   def ssl_enabled?
-    Rails.env.production? && !request.format.symbol == :json
+    Rails.env.production? && request.format.symbol != :json
   end
 
   def strict_transport_security

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      respond_to do |format|
+        format.html { render text: 'html' }
+        format.json { render text: 'json' }
+      end
+    end
+  end
+
+  describe 'force_ssl' do
+    around do |example|
+      original_env = Rails.env
+      Rails.env = 'production'
+      example.run
+      Rails.env = original_env
+    end
+
+    context 'http access' do
+      before do
+        get :index, format: format, locale: 'en-US'
+      end
+
+      context 'html format' do
+        let(:format) { :html }
+
+        it { expect(response.status).to eq 301 }
+        it { expect(response.headers['Strict-Transport-Security']).to be_blank }
+      end
+
+      context 'json format' do
+        let(:format) { :json }
+
+        it { expect(response.status).to eq 200 }
+        it { expect(response.headers['Strict-Transport-Security']).to be_blank }
+      end
+    end
+
+    context 'https access' do
+      before do
+        request.headers['HTTPS'] = 'on'
+        get :index, format: format, locale: 'en-US'
+      end
+
+      context 'html format' do
+        let(:format) { :html }
+
+        it { expect(response.status).to eq 200 }
+        it { expect(response.headers['Strict-Transport-Security']).to be_present }
+      end
+
+      context 'json format' do
+        let(:format) { :json }
+
+        it { expect(response.status).to eq 200 }
+        it { expect(response.headers['Strict-Transport-Security']).to be_present }
+      end
+    end
+  end
+end


### PR DESCRIPTION
It seems that condition (`ssl_enabled?`) to enable SSL access always returns `false`. This condition is expected to return `false` only when coming request is in JSON format.

Currently, we have

```ruby
force_ssl if: :ssl_enabled?

def ssl_enabled?
  Rails.env.production? && !request.format.symbol == :json
end
```

but,

```pry
[1] pry(main)> !Mime::JSON.symbol == :json
=> false
[2] pry(main)> !Mime::HTML.symbol == :json
=> false
```

so, the `ssl_enabled?` always returns `false`.