### PR TITLE
Fix datetime format in JSON, not to include milliseconds

### DIFF
--- a/config/initializers/datetime.rb
+++ b/config/initializers/datetime.rb
@@ -1,0 +1,7 @@
+[Date, DateTime, Time, ActiveSupport::TimeWithZone].each do |klass|
+  klass.class_eval do
+    def as_json(*)
+      xmlschema(0)
+    end
+  end
+end

--- a/config/initializers/datetime.rb
+++ b/config/initializers/datetime.rb
@@ -1,3 +1,4 @@
+# Need to send datetime without millisecond for Drivecast iOS app
 [Date, DateTime, Time, ActiveSupport::TimeWithZone].each do |klass|
   klass.class_eval do
     def as_json(*)

--- a/spec/integration/api/bgeigie_imports_spec.rb
+++ b/spec/integration/api/bgeigie_imports_spec.rb
@@ -46,6 +46,9 @@ feature "/bgeigie_imports API endpoint", type: :feature do
     end
   end
 
+  # iOS SDCSafecastAPIRouter
+
+  # GET .ImportLogs [:]
   context 'GET /en-US/bgeigie_imports.json' do
     let!(:bgeigie_import) { Fabricate(:bgeigie_import, user: @user, cities: 'Tokyo', credits: 'John Doe') }
     before do
@@ -76,6 +79,40 @@ feature "/bgeigie_imports API endpoint", type: :feature do
     # format that Drivecast iOS app accepts.
     def parse_iso8601(date_str)
       Time.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ')
+    end
+  end
+
+  # PUT .EditImportLogMetadata(let id, _, _, _, _, _)
+  #   ["api_key": key, "bgeigie_import[credits]": credits,
+  #   "bgeigie_import[cities]": cities, "bgeigie_import[name]": name,
+  #   "bgeigie_import[description]": description]
+  context 'PUT /bgeigie_imports/:id.json' do
+    let!(:bgeigie_import) { Fabricate(:bgeigie_import, user: @user, cities: 'Tokyo', credits: 'John Doe') }
+    before do
+      login_as(@user, scope: :user)
+
+      put "/en-US/bgeigie_imports/#{bgeigie_import.id}.json", post_params
+
+    end
+
+    it { expect(response.status).to eq(204) } # No Content
+
+    subject { bgeigie_import.reload }
+
+    it { expect(subject.credits).to eq('Jane Doe') }
+    it { expect(subject.cities).to eq('Osaka') }
+    it { expect(subject.name).to eq('My Import') }
+    it { expect(subject.description).to eq('Doh!') }
+
+    def post_params
+      {
+        # XXX: iOS app sends this, but not necesarry.
+        'api_key' => @user.authentication_token,
+        'bgeigie_import[credits]' => 'Jane Doe',
+        'bgeigie_import[cities]' => 'Osaka',
+        'bgeigie_import[name]' => 'My Import',
+        'bgeigie_import[description]' => 'Doh!'
+      }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ RSpec.configure do |config|
   config.include EmailSpec::Matchers
   config.include ActionDispatch::TestProcess
   config.include Devise::TestHelpers, type: :controller
+  config.include Warden::Test::Helpers
 
   # == Mock Framework
   #
@@ -61,6 +62,8 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean_with(:truncation)
+
+    Warden.test_mode!
   end
 
   config.before(:each) do
@@ -68,6 +71,8 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
+    Warden.test_reset!
+
     DatabaseCleaner.clean
   end
 


### PR DESCRIPTION
Rails 4 includes millisecond in datetime string of JSON format. This causes Drivecast iOS app an error described in Safecast/Drive-ios#4 .
