### PR TITLE
Use #size instead of #count on bgeigie_imports#show page

### DIFF
--- a/app/views/bgeigie_imports/_process_log.html.erb
+++ b/app/views/bgeigie_imports/_process_log.html.erb
@@ -14,7 +14,7 @@
   <li>
     <%= t '.import_bgeigie_logs' -%>
     <%- if @bgeigie_import.bgeigie_logs.any? -%>
-      (<%= t('.count_found', :count => @bgeigie_import.bgeigie_logs.count) %>)
+      (<%= t('.count_found', :count => @bgeigie_import.bgeigie_logs.size) %>)
     <%- else -%>
       (<%= t '.none_found' -%>)
     <%- end -%>

--- a/app/views/bgeigie_imports/_static_metadata.html.erb
+++ b/app/views/bgeigie_imports/_static_metadata.html.erb
@@ -22,8 +22,7 @@
       <%= t('.number_of_measurements') %>
     </dt>
     <dd>
-      <%= '-' unless @bgeigie_import.processed? %>
-      <%= @bgeigie_import.bgeigie_logs.count if @bgeigie_import.processed? %>
+      <%= @bgeigie_import.processed? ? @bgeigie_import.bgeigie_logs.size : '-' %>
     </dd>
   </dl>
 </div>


### PR DESCRIPTION
Since we disallow web crawler robots access api, loading time of `bgeigie_imports#show` has been standing out on NewRelic. The breakdown of `BgeigieImportsController#show` (`bgeigie_imports#show`) shows that some view files taking long time. Inspecting those files and partial files, `#count` methods are called in some of files.

```
There's also the differences between `#count`, `#length`, and `#size` on
ActiveRecord::Relation. `#count` will always perform a count query,
`#length` will load up the records, and call `#length` on the resulting
array, and `#size` will do the smart thing based on whether or not we've
loaded. TLDR: use `#size`, unless you're calling it immediately before
you need to load the real records, in which case use `#length`. Never use
`#count`, since `#size` will skip the query if it can.
```
http://batsov.com/articles/2014/02/17/the-elements-of-style-in-ruby-number-13-length-vs-size-vs-count/#comment-1248998887