### PR TITLE
Add help text for subtype on edit metadata page

### DIFF
--- a/config/locales/simple_form.en-US.yml
+++ b/config/locales/simple_form.en-US.yml
@@ -48,6 +48,11 @@ en-US:
         credits: '(comma-separated. eg. "Sean Bonner, Pieter Franken")'
         cities: '(comma-separated. eg. "Dublin, Tokyo")'
         height: (in metres)
+        subtype: "<ul>
+<li>Drive - car, bike, walk, boat, terrestrial</li>
+<li>Surface - near immediate surface, alpha/beta activity</li>
+<li>Cosmic - aircraft, balloons, rockets</li>
+</ul>"
     #   defaults:
     #     username: 'User name to sign in.'
     #     password: 'No special characters, please.'


### PR DESCRIPTION
This PR is for #270

In this PR, descriptions are shown in the following.

<img width="608" alt="bgeigie_import__7____bgeigie_imports____safecast_api" src="https://cloud.githubusercontent.com/assets/34205/16610871/0589a16a-4399-11e6-9521-cfe61bd980a6.png">

And it can be done as @Frangible suggested in #270.

![text_in_item](https://cloud.githubusercontent.com/assets/34205/16616525/b23f2974-43b8-11e6-82f0-d3c0298e75e4.png)
