### PR TITLE
Enable config.secret_key_base

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,9 +4,7 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-# rubocop:disable Metrics/LineLength
-Safecast::Application.config.secret_token = '39c00ee18c6a2edd472f8f8b5954b6a332636e32b4c80ed9abc9053cc33bf7f1913d4cb6267ea741d10b48acfd9b3b3df2336fd02de83a4290509bc5d97c0edd'
-# TODO: uncomment following line when rails 4 deployment is settled
-#       See "4.7 Action Pack" in http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-3-2-to-rails-4-0
-# Safecast::Application.config.secret_key_base = 'f0906ce1f97f1d3a7b1fba927645046ef10d9f7766d2141e023dc074529d9e2b10294e9a6490b04aff9d95ce4764c65e3280a30e1dd2e94f37ba22381ec2b4a4'
-# rubocop:enable Metrics/LineLength
+Safecast::Application.config.secret_token =
+  '39c00ee18c6a2edd472f8f8b5954b6a332636e32b4c80ed9abc9053cc33bf7f1913d4cb6267ea741d10b48acfd9b3b3df2336fd02de83a4290509bc5d97c0edd'
+Safecast::Application.config.secret_key_base =
+  'f0906ce1f97f1d3a7b1fba927645046ef10d9f7766d2141e023dc074529d9e2b10294e9a6490b04aff9d95ce4764c65e3280a30e1dd2e94f37ba22381ec2b4a4'


### PR DESCRIPTION
```
DEPRECATION WARNING: You didn't set config.secret_key_base. Read the upgrade doc
umentation to learn more about this new config option. (called from instance_exe
c at .../rbenv/1.0.0/versions/2.1.10/gemsets/safecast/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:441)
```