### PR TITLE
Should address issue #99 - removed from field user/moderator emails and…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 2.0.0p648
+   ruby 2.1.10p492
 
 BUNDLED WITH
-   1.12.5
+   1.13.5

--- a/app/controllers/bgeigie_imports_controller.rb
+++ b/app/controllers/bgeigie_imports_controller.rb
@@ -44,13 +44,13 @@ class BgeigieImportsController < ApplicationController # rubocop:disable Metrics
 
   def send_email
     @bgeigie_import = BgeigieImport.find(params[:id])
-    @bgeigie_import.send_email(params[:email_body], current_user.email)
+    @bgeigie_import.send_email(params[:email_body])
     redirect_to @bgeigie_import
   end
 
   def contact_moderator
     @bgeigie_import = BgeigieImport.find(params[:id])
-    @bgeigie_import.contact_moderator(params[:email_body], current_user.email)
+    @bgeigie_import.contact_moderator(params[:email_body])
     redirect_to @bgeigie_import
   end
 

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -30,23 +30,19 @@ class Notifications < ActionMailer::Base
     )
   end
 
-  def send_email(import, body, sender)
+  def send_email(import, body)
     @import = import
     @body = body
-    @sender = sender
     mail(
-      from: sender,
       to: import.user.email,
       subject: "Email from Safecast Moderator regarding your Safecast Import - #{import.filename}"
     )
   end
 
-  def contact_moderator(import, body, sender)
+  def contact_moderator(import, body)
     @import = import
     @body = body
-    @sender = sender
     mail(
-      from: sender,
       to: import.rejected_by,
       subject: "Email from Safecast User regarding Safecast Import - #{import.filename}"
     )

--- a/app/models/bgeigie_import.rb
+++ b/app/models/bgeigie_import.rb
@@ -105,12 +105,12 @@ class BgeigieImport < MeasurementImport # rubocop:disable Metrics/ClassLength
     update_column(:rejected_by, nil)
   end
 
-  def send_email(email_body, sender)
-    Notifications.send_email(self, email_body, sender).deliver
+  def send_email(email_body)
+    Notifications.send_email(self, email_body).deliver
   end
 
-  def contact_moderator(email_body, sender)
-    Notifications.contact_moderator(self, email_body, sender).deliver
+  def contact_moderator(email_body)
+    Notifications.contact_moderator(self, email_body).deliver
   end
 
   def finalize!

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Notifications, type: :mailer do
       end
     end
 
-    subject { described_class.send_email(import, 'e-mail body', 'sender@example.org') }
+    subject { described_class.send_email(import, 'e-mail body') }
 
     it { is_expected.to be_present }
   end
@@ -22,7 +22,7 @@ RSpec.describe Notifications, type: :mailer do
       end
     end
 
-    subject { described_class.contact_moderator(import, 'e-mail body', 'sender@example.org') }
+    subject { described_class.contact_moderator(import, 'e-mail body') }
 
     it { is_expected.to be_present }
   end


### PR DESCRIPTION
… used mailer email instead 

removed from field user/moderator emails and used mailer email instead as mail server did not send messages on production when using user/moderator emails in the from email field.

Wondering al0s if Gemfile.lock changes should be pushed here? SourceTree seems to want to.