### PR TITLE
add links to wiki pages Linux and Docket setup in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Happy translating!
 See one of the wiki pages for instructions on setting up for local development:
 
 * [Dev: Setup on OS X](https://github.com/Safecast/safecastapi/wiki/Dev:-Setup-on-OS-X)
+* [Dev: Setup on Linux (Ubuntu 16.04)](https://github.com/Safecast/safecastapi/wiki/Dev:-Setup-on-Linux-(Ubuntu-16.04))
+* [Dev: Using Docker](https://github.com/Safecast/safecastapi/wiki/Dev:-Using-Docker)
 
 ### Licensing
 Licensing can be confusing. We’ll try to make it a little less so.


### PR DESCRIPTION
Added links to Linux and Docker setup in the Readme.

Also modified the Linux setup : 
* added the following lines: 
```
#You can then run this command to avoid tracking the modificiation in the database.yml (and avoid pushing them in your next pull request - it would mess with other collaborators database settings).

git update-index --assume-unchanged config/database.yml
```
in order to avoid new linux collaborators to push their modified database.yml in their next pull request.

Let me know if you have any ideas on how to deal with this `script_dir` path issue between Mac and Linux (keeping in mind that Linux path contains Postgresql and Postgis version number, and must be adapted to each linux collaborators setup).