### PR TITLE
I18n simple form issue

### DIFF
--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -170,10 +170,6 @@ en-US:
       create: Create %{model}
       submit: Save %{model}
       update: Update %{model}
-      # bgeigie_import:
-      #   create: Create Bgeigie import
-      # device:
-      #   create: Create Device
   if_you_have_a_bgeigie: If you have a bGeigie
   imports_awaiting_approval: imports awaiting approval
   it_may_take_a_few_minutes_to_process: It may take a few minutes to process.

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -14,9 +14,9 @@ en-US:
   cancel: Cancel
   devices:
     new:
-      add_new: 
+      add_new:
     index:
-      sensor: 
+      sensor:
   email: Email
   height: Height
   radiation_type: Radiation Type
@@ -35,7 +35,7 @@ en-US:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -61,7 +61,7 @@ en-US:
       long: ! '%B %d, %Y'
       short: ! '%b %d'
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -170,10 +170,10 @@ en-US:
       create: Create %{model}
       submit: Save %{model}
       update: Update %{model}
-      bgeigie_import:
-        create: Create Bgeigie import
-      device:
-        create: Create Device
+      # bgeigie_import:
+      #   create: Create Bgeigie import
+      # device:
+      #   create: Create Device
   if_you_have_a_bgeigie: If you have a bGeigie
   imports_awaiting_approval: imports awaiting approval
   it_may_take_a_few_minutes_to_process: It may take a few minutes to process.
@@ -286,15 +286,15 @@ en-US:
       reasons: {}
       inactive_signed_up: ''
   user:
-    email: 
-    password: 
-    remember_me: 
+    email:
+    password:
+    remember_me:
     name: ''
     password_confirmation: ''
     new:
-      email: 
-      password: 
-      remember_me: 
+      email:
+      password:
+      remember_me:
   activerecord:
     attributes:
       device:
@@ -332,19 +332,19 @@ en-US:
       mark: ! '*'
       text: required
   bgeigie_import: Bgeigie import
-  edit_details_status: 
+  edit_details_status:
   layouts:
     submit_nav:
-      submit_a_single_measurement: 
-  no_devices: 
+      submit_a_single_measurement:
+  no_devices:
   shared:
     dashboard_navigation:
-      devices: 
-      imports: 
-      measurements: 
+      devices:
+      imports:
+      measurements:
   dashboards:
     show:
-      bgeigie_imports: 
-      imports_awaiting_approval: 
-      submissions: 
-  captured_at: 
+      bgeigie_imports:
+      imports_awaiting_approval:
+      submissions:
+  captured_at:


### PR DESCRIPTION
For some reason, I had this i18n problem back.
Therefore, I made some modifications in the i18n file. I kept the simple_form i18n file, and removed the following lines in the en-US file:

```
-      bgeigie_import:
-        create: Create Bgeigie import
-      device:
-        create: Create Device
```

I made a pull request for this as well.
Let me know if you think of a better solution.
(I think it's better to keep the simple_form i18n, and not merging it to the en_US, as it is the standard configuration for simple_form internationalization)