### PR TITLE
Exclude rejected drives from "Imports Awaiting Approval" count on Dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -6,7 +6,4 @@ class DashboardsController < ApplicationController
     end
     @unapproved_bgeigie_imports = BgeigieImport.unapproved
   end
-
-  alias_method :new, :show
-  alias_method :index, :show
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,9 +1,6 @@
 class DashboardsController < ApplicationController
   def show
-    unless user_signed_in?
-      render 'home/show'
-      return
-    end
+    return render 'home/show' unless user_signed_in?
     @unapproved_bgeigie_imports = BgeigieImport.unapproved
   end
 end

--- a/app/models/bgeigie_import.rb
+++ b/app/models/bgeigie_import.rb
@@ -20,7 +20,7 @@ class BgeigieImport < MeasurementImport # rubocop:disable Metrics/ClassLength
   %i(submitted processed done).each do |status|
     scope status, -> { where(status: status) }
   end
-  scope :unapproved, -> { where(approved: false) }
+  scope :unapproved, -> { where(approved: false).where(rejected: false) }
 
   store :status_details, accessors: [
     :process_file,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Safecast::Application.routes.draw do
     end
 
     resource :home, controller: :home, only: :show
-    resource :dashboard
+    resource :dashboard, only: %i(show)
     resource :profile
 
     namespace :bgeigie_imports do

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe DashboardsController, type: :controller do
+  describe 'GET #show' do
+    before { get :show }
+
+    context 'when user is not logged in' do
+      it { is_expected.to render_template('home/show') }
+    end
+  end
+end


### PR DESCRIPTION
This is part of #406. This PR should exclude to count rejected drive from "Imports Awaiting Approval" on Dashboard.