### PR TITLE
Return counter cache for User#measurements_count

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,10 +33,6 @@ class User < ActiveRecord::Base
     )
   end
 
-  def measurements_count
-    measurements.count
-  end
-
   def to_builder
     Jbuilder.new do |user|
       user.call(self, :id, :name, :number_of_measurements)


### PR DESCRIPTION
We've refreshed the counter caches so we should be good for some time. Having this method means we can't display top users since it will time out attempting to actually count users with many measurements.

Connected to https://github.com/Safecast/safecastapi/issues/432