### PR TITLE
Format date/time in ISO format in filter dialog

### DIFF
--- a/app/views/layouts/_datetime_picker.html.erb
+++ b/app/views/layouts/_datetime_picker.html.erb
@@ -2,7 +2,7 @@
   <%= text_field_tag attr_name, params[attr_name],
         :class => 'span2',
         :data => {
-          :format => 'dd/MM/yyyy hh:mm:ss'
+          :format => 'yyyy/MM/dd hh:mm:ss'
         },
         :placeholder => human_label(model_name, attr_name) %>
   <span class="add-on activate-tooltip"


### PR DESCRIPTION
Error in #446 seems to be caused because filter dialog creates date/time in MDY format (like "14/04/2018 12:34:56"). This PR change filter to create in ISO format (like "2018/04/14 12:34:56"). It has used MDY format since beginning. I wonder if it was working before...
