### PR TITLE
Add Swagger document for measurements

### DIFF
--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -16,6 +16,6 @@ class ApiDocsController < ActionController::Base
   end
 
   def index
-    render json: Swagger::Blocks.build_root_json([UsersController, User, self.class])
+    render json: Swagger::Blocks.build_root_json([Measurement, MeasurementsController, User, UsersController, self.class])
   end
 end

--- a/app/controllers/concerns/swagger_blocks/controllers/measurements.rb
+++ b/app/controllers/concerns/swagger_blocks/controllers/measurements.rb
@@ -1,0 +1,68 @@
+module SwaggerBlocks
+  module Controllers
+    module Measurements
+      extend ActiveSupport::Concern
+
+      included do
+        include Swagger::Blocks
+
+        swagger_path '/measurements' do
+          operation :get do
+            key :summary, 'All Measurements'
+            key :description, 'Returns all measurements'
+            response 200 do
+              key :description, 'measurement response'
+              schema do
+                key :type, :array
+                items do
+                  key :'$ref', :Measurement
+                end
+              end
+            end
+          end
+        end
+        swagger_path '/measurements/{id}' do
+          operation :get do
+            key :summary, 'Find Measurement by ID'
+            key :description, 'Return a single measurement'
+            parameter do
+              key :name, :id
+              key :in, :path
+              key :description, 'ID of measurement of fetch'
+              key :required, true
+              key :type, :integer
+              key :format, :int64
+            end
+            response 200 do
+              key :description, 'measurement response'
+              schema do
+                key :'$ref', :Measurement
+              end
+            end
+          end
+        end
+        swagger_path '/measurements' do
+          operation :post do
+            key :summary, 'Add New Measurement'
+            key :description, 'Add a new measurement'
+            parameter do
+              key :name, :measurement
+              key :in, :body
+              key :description, 'Measurement to add'
+              key :required, true
+              schema do
+                key :'$ref', :MeasurementInput
+              end
+            end
+            response 200 do
+              key :description, 'measurement response'
+              schema do
+                key :'$ref', :Measurement
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -1,4 +1,6 @@
 class MeasurementsController < ApplicationController
+  include SwaggerBlocks::Controllers::Measurements
+
   class << self
     def attribute_names_to_be_wrapped
       names = Measurement.attribute_names

--- a/app/models/concerns/swagger_blocks/models/measurement.rb
+++ b/app/models/concerns/swagger_blocks/models/measurement.rb
@@ -1,0 +1,79 @@
+module SwaggerBlocks
+  module Models
+    module Measurement
+      extend ActiveSupport::Concern
+
+      included do
+        include Swagger::Blocks
+
+        swagger_schema :Measurement do
+          key :required, [:location, :unit, :value]
+          property :id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :captured_at do
+            key :type, :string
+            key :format, :'date-time'
+          end
+          property :channel_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :device_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :devicetype_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :height do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :latitude do
+            key :type, :number
+            key :format, :double
+          end
+          property :location_name do
+            key :type, :string
+          end
+          property :longitude do
+            key :type, :number
+            key :format, :double
+          end
+          property :measurement_import_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :original_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :sensor_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :station_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :unit do
+            key :type, :string
+          end
+          property :user_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :value do
+            key :type, :integer
+            key :format, :int64
+          end
+        end
+
+        include MeasurementInput
+      end
+    end
+  end
+end

--- a/app/models/concerns/swagger_blocks/models/measurement_input.rb
+++ b/app/models/concerns/swagger_blocks/models/measurement_input.rb
@@ -1,0 +1,68 @@
+module SwaggerBlocks
+  module Models
+    module MeasurementInput
+      extend ActiveSupport::Concern
+
+      included do
+        swagger_schema :MeasurementInput do
+          property :captured_at do
+            key :type, :string
+            key :format, :'date-time'
+          end
+          property :channel_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :device_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :devicetype_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :height do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :latitude do
+            key :type, :number
+            key :format, :double
+          end
+          property :location_name do
+            key :type, :string
+          end
+          property :longitude do
+            key :type, :number
+            key :format, :double
+          end
+          property :measurement_import_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :radiation do
+            key :type, :string
+          end
+          property :sensor_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :station_id do
+            key :type, :integer
+            key :format, :int64
+          end
+          property :surface do
+            key :type, :string
+          end
+          property :unit do
+            key :type, :string
+          end
+          property :value do
+            key :type, :integer
+            key :format, :int64
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -3,6 +3,7 @@ class Measurement < ActiveRecord::Base
                               RGeo::Geographic.spherical_factory(srid: 4326))
 
   include MeasurementConcerns
+  include SwaggerBlocks::Models::Measurement
 
   validates :location,  presence: true
   validates :value,     presence: true


### PR DESCRIPTION
This PR adds Swagger documentation for measurement related API endpoints and model.

`/api_docs` should produce JSON document like in details.

Fixes https://github.com/Safecast/safecastapi/issues/440

<details>

```json
{"swagger":"2.0","info":{"version":"1.0.0","title":"Safecast API","description":"Safecast API","contact":{"name":"Safecast"}},"host":"api.safecast.org","basePath":"/api_docs","paths":{"/measurements":{"get":{"summary":"All Measurements","description":"Returns all measurements","responses":{"200":{"description":"measurement response","schema":{"type":"array","items":{"$ref":"#/definitions/Measurement"}}}}},"post":{"summary":"Add New Measurement","description":"Add a new measurement","parameters":[{"name":"measurement","in":"body","description":"Measurement to add","required":true,"schema":{"$ref":"#/definitions/MeasurementInput"}}],"responses":{"200":{"description":"measurement response","schema":{"$ref":"#/definitions/Measurement"}}}}},"/measurements/{id}":{"get":{"summary":"Find Measurement by ID","description":"Return a single measurement","parameters":[{"name":"id","in":"path","description":"ID of measurement of fetch","required":true,"type":"integer","format":"int64"}],"responses":{"200":{"description":"measurement response","schema":{"$ref":"#/definitions/Measurement"}}}}},"/users":{"get":{"summary":"All Users","description":"Returns all users","responses":{"200":{"description":"user response","schema":{"type":"array","items":{"$ref":"#/definitions/User"}}}}}}},"definitions":{"Measurement":{"required":["location","unit","value"],"properties":{"id":{"type":"integer","format":"int64"},"captured_at":{"type":"string","format":"date-time"},"channel_id":{"type":"integer","format":"int64"},"device_id":{"type":"integer","format":"int64"},"devicetype_id":{"type":"integer","format":"int64"},"height":{"type":"integer","format":"int64"},"latitude":{"type":"number","format":"double"},"location_name":{"type":"string"},"longitude":{"type":"number","format":"double"},"measurement_import_id":{"type":"integer","format":"int64"},"original_id":{"type":"integer","format":"int64"},"sensor_id":{"type":"integer","format":"int64"},"station_id":{"type":"integer","format":"int64"},"unit":{"type":"string"},"user_id":{"type":"integer","format":"int64"},"value":{"type":"integer","format":"int64"}}},"MeasurementInput":{"properties":{"captured_at":{"type":"string","format":"date-time"},"channel_id":{"type":"integer","format":"int64"},"device_id":{"type":"integer","format":"int64"},"devicetype_id":{"type":"integer","format":"int64"},"height":{"type":"integer","format":"int64"},"latitude":{"type":"number","format":"double"},"location_name":{"type":"string"},"longitude":{"type":"number","format":"double"},"measurement_import_id":{"type":"integer","format":"int64"},"radiation":{"type":"string"},"sensor_id":{"type":"integer","format":"int64"},"station_id":{"type":"integer","format":"int64"},"surface":{"type":"string"},"unit":{"type":"string"},"value":{"type":"integer","format":"int64"}}},"User":{"required":["id","email","name"],"properties":{"id":{"type":"integer","format":"int64"},"name":{"type":"string"},"measurements_count":{"type":"integer","format":"int64"}}}}}
```

