### PR TITLE
Add spec for bgeigie_imports#reject

### DIFF
--- a/spec/controllers/bgeigie_imports_controller_spec.rb
+++ b/spec/controllers/bgeigie_imports_controller_spec.rb
@@ -194,6 +194,31 @@ RSpec.describe BgeigieImportsController, type: :controller do
     it { expect(bgeigie_import.rejected_by).to be_nil }
   end
 
+  describe 'PATCH #reject' do
+    context 'sign in as administrator' do
+      context 'processed import without metadata' do
+        let(:bgeigie_import) { Fabricate(:bgeigie_import, status: :processed) }
+
+        before do
+          sign_in administrator
+
+          # just make sure import has no required metadata
+          expect(bgeigie_import).not_to be_metadata_added
+
+          patch :reject, id: bgeigie_import.id
+
+          bgeigie_import.reload
+        end
+
+        it 'should reject import' do
+          expect(response).to redirect_to(assigns(:bgeigie_import))
+          expect(bgeigie_import).to be_rejected
+          expect(bgeigie_import.rejected_by).to eq(administrator.email)
+        end
+      end
+    end
+  end
+
   describe 'PATCH #send_email' do
     let(:bgeigie_import) { Fabricate(:bgeigie_import, status: :unprocessed) }
 


### PR DESCRIPTION
## ~~This PR have to be merged after #460 is merged.~~

Connected to #407.

b611473cf173c0658cdd185485686df962e7d390 is the only commit for this PR.

It adds a spec for bgeigie_import#reject to make sure bGeigie import without metadata can be rejected.
