### PR TITLE
Use bundler 1.17.3 in SemaphoreCI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ blocks:
           - checkout
           - docker-compose up -d elasticsearch postgresql
           - rbenv install -s $(cat .ruby-version)
-          - gem install bundler
+          - gem install bundler -v 1.17.3
           - bundle install -j 2 --deployment --path vendor/bundle
           - rm -f config/database.yml
           - cp config/database.yml.docker config/database.yml


### PR DESCRIPTION
```
gem install bundler
--
  | Fetching: bundler-2.0.1.gem (100%)
  | ERROR:  Error installing bundler:
  | bundler requires Ruby version >= 2.3.0.
  | exit code: 1 duration: 0s
```