### PR TITLE
Use PostgreSQL count estimate trick on dashboard page

### DIFF
--- a/.ebextensions/rails.config
+++ b/.ebextensions/rails.config
@@ -1,3 +1,0 @@
-container_commands:
-  configure_database:
-    command: mv config/database.yml{.beanstalk,}

--- a/.elasticbeanstalk/package.sh
+++ b/.elasticbeanstalk/package.sh
@@ -28,6 +28,8 @@ VERSION="${EB_APP_NAME}-${CLEAN_BRANCH_NAME}-${BUILD_NUMBER}"
 
 PACKAGE="${VERSION}.zip"
 
+cp config/database.yml.beanstalk config/database.yml
+
 .elasticbeanstalk/package.py "${PACKAGE}"
 
 aws s3 cp --no-progress ".elasticbeanstalk/app_versions/${PACKAGE}" "s3://${S3_BUCKET_NAME}/${EB_APP_NAME}/"

--- a/app/models/bgeigie_import.rb
+++ b/app/models/bgeigie_import.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BgeigieImport < MeasurementImport # rubocop:disable Metrics/ClassLength
+  include ApproximateCount
   # States:
   # - unprocessed
   # - processed

--- a/app/models/concerns/approximate_count.rb
+++ b/app/models/concerns/approximate_count.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ApproximateCount
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def approximate_count
+      count_by_sql("SELECT reltuples FROM pg_class WHERE relname = '#{table_name}'")
+    end
+  end
+end

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Measurement < ActiveRecord::Base
+  include ApproximateCount
   include MeasurementConcerns
   include SwaggerBlocks::Models::Measurement
 

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -40,14 +40,14 @@
       <li>
         <%= link_to [:measurements] do %>
           <em>
-            <%= number_with_delimiter current_user.measurements.count %>
+            <%= number_to_human current_user.measurements.approximate_count %>
           </em>
           <%= t('.submissions') %>
         <%- end -%>
       </li>
       <li>
         <%= link_to [:bgeigie_imports] do %>
-          <em><%= current_user.bgeigie_imports.count  %></em>
+          <em><%= number_to_human current_user.bgeigie_imports.approximate_count  %></em>
           <%= t('.bgeigie_imports') -%>
         <%- end -%>
       </li>

--- a/spec/models/measurement_spec.rb
+++ b/spec/models/measurement_spec.rb
@@ -36,4 +36,10 @@ RSpec.describe Measurement, type: :model do
       end
     end
   end
+
+  describe '#approximate_count' do
+    it 'shoulde return approximate count' do
+      expect(described_class.approximate_count).to be_a(Numeric)
+    end
+  end
 end


### PR DESCRIPTION
Implement method that described in https://wiki.postgresql.org/wiki/Count_estimate

Since number returned by `approximate_count` is approximate, I changed to use [`number_to_human``(https://api.rubyonrails.org/classes/ActionView/Helpers/NumberHelper.html#method-i-number_to_human)  in view. This method will display like `1.23 Billion` for `1234567890`. 