### PR TITLE
Fix db/structure.sql

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,19 +2,31 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.5
--- Dumped by pg_dump version 11.5
+-- Dumped from database version 9.5.14
+-- Dumped by pg_dump version 9.5.14
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
 
 --
 -- Name: postgis; Type: SCHEMA; Schema: -; Owner: -
@@ -1061,155 +1073,155 @@ CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING b
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO schema_migrations (version) VALUES ('20111123174941');
+INSERT INTO public.schema_migrations (version) VALUES ('20111123174941');
 
-INSERT INTO schema_migrations (version) VALUES ('20111123190839');
+INSERT INTO public.schema_migrations (version) VALUES ('20111123190839');
 
-INSERT INTO schema_migrations (version) VALUES ('20111124211843');
+INSERT INTO public.schema_migrations (version) VALUES ('20111124211843');
 
-INSERT INTO schema_migrations (version) VALUES ('20111128163114');
+INSERT INTO public.schema_migrations (version) VALUES ('20111128163114');
 
-INSERT INTO schema_migrations (version) VALUES ('20111128163317');
+INSERT INTO public.schema_migrations (version) VALUES ('20111128163317');
 
-INSERT INTO schema_migrations (version) VALUES ('20111128171949');
+INSERT INTO public.schema_migrations (version) VALUES ('20111128171949');
 
-INSERT INTO schema_migrations (version) VALUES ('20111130103929');
+INSERT INTO public.schema_migrations (version) VALUES ('20111130103929');
 
-INSERT INTO schema_migrations (version) VALUES ('20111130104648');
+INSERT INTO public.schema_migrations (version) VALUES ('20111130104648');
 
-INSERT INTO schema_migrations (version) VALUES ('20111130132854');
+INSERT INTO public.schema_migrations (version) VALUES ('20111130132854');
 
-INSERT INTO schema_migrations (version) VALUES ('20111210075847');
+INSERT INTO public.schema_migrations (version) VALUES ('20111210075847');
 
-INSERT INTO schema_migrations (version) VALUES ('20111210234133');
+INSERT INTO public.schema_migrations (version) VALUES ('20111210234133');
 
-INSERT INTO schema_migrations (version) VALUES ('20111210235123');
+INSERT INTO public.schema_migrations (version) VALUES ('20111210235123');
 
-INSERT INTO schema_migrations (version) VALUES ('20111210235206');
+INSERT INTO public.schema_migrations (version) VALUES ('20111210235206');
 
-INSERT INTO schema_migrations (version) VALUES ('20111210235226');
+INSERT INTO public.schema_migrations (version) VALUES ('20111210235226');
 
-INSERT INTO schema_migrations (version) VALUES ('20111210235259');
+INSERT INTO public.schema_migrations (version) VALUES ('20111210235259');
 
-INSERT INTO schema_migrations (version) VALUES ('20111213000431');
+INSERT INTO public.schema_migrations (version) VALUES ('20111213000431');
 
-INSERT INTO schema_migrations (version) VALUES ('20111214134716');
+INSERT INTO public.schema_migrations (version) VALUES ('20111214134716');
 
-INSERT INTO schema_migrations (version) VALUES ('20111214154833');
+INSERT INTO public.schema_migrations (version) VALUES ('20111214154833');
 
-INSERT INTO schema_migrations (version) VALUES ('20111214161111');
+INSERT INTO public.schema_migrations (version) VALUES ('20111214161111');
 
-INSERT INTO schema_migrations (version) VALUES ('20111214162214');
+INSERT INTO public.schema_migrations (version) VALUES ('20111214162214');
 
-INSERT INTO schema_migrations (version) VALUES ('20111214224431');
+INSERT INTO public.schema_migrations (version) VALUES ('20111214224431');
 
-INSERT INTO schema_migrations (version) VALUES ('20111214224611');
+INSERT INTO public.schema_migrations (version) VALUES ('20111214224611');
 
-INSERT INTO schema_migrations (version) VALUES ('20120103182931');
+INSERT INTO public.schema_migrations (version) VALUES ('20120103182931');
 
-INSERT INTO schema_migrations (version) VALUES ('20120103213502');
+INSERT INTO public.schema_migrations (version) VALUES ('20120103213502');
 
-INSERT INTO schema_migrations (version) VALUES ('20120110185237');
+INSERT INTO public.schema_migrations (version) VALUES ('20120110185237');
 
-INSERT INTO schema_migrations (version) VALUES ('20120116133915');
+INSERT INTO public.schema_migrations (version) VALUES ('20120116133915');
 
-INSERT INTO schema_migrations (version) VALUES ('20120116134744');
+INSERT INTO public.schema_migrations (version) VALUES ('20120116134744');
 
-INSERT INTO schema_migrations (version) VALUES ('20120116144757');
+INSERT INTO public.schema_migrations (version) VALUES ('20120116144757');
 
-INSERT INTO schema_migrations (version) VALUES ('20120116150229');
+INSERT INTO public.schema_migrations (version) VALUES ('20120116150229');
 
-INSERT INTO schema_migrations (version) VALUES ('20120306150302');
+INSERT INTO public.schema_migrations (version) VALUES ('20120306150302');
 
-INSERT INTO schema_migrations (version) VALUES ('20120306202021');
+INSERT INTO public.schema_migrations (version) VALUES ('20120306202021');
 
-INSERT INTO schema_migrations (version) VALUES ('20120307130255');
+INSERT INTO public.schema_migrations (version) VALUES ('20120307130255');
 
-INSERT INTO schema_migrations (version) VALUES ('20120307130803');
+INSERT INTO public.schema_migrations (version) VALUES ('20120307130803');
 
-INSERT INTO schema_migrations (version) VALUES ('20120307150105');
+INSERT INTO public.schema_migrations (version) VALUES ('20120307150105');
 
-INSERT INTO schema_migrations (version) VALUES ('20120307175658');
+INSERT INTO public.schema_migrations (version) VALUES ('20120307175658');
 
-INSERT INTO schema_migrations (version) VALUES ('20120307232457');
+INSERT INTO public.schema_migrations (version) VALUES ('20120307232457');
 
-INSERT INTO schema_migrations (version) VALUES ('20120315211955');
+INSERT INTO public.schema_migrations (version) VALUES ('20120315211955');
 
-INSERT INTO schema_migrations (version) VALUES ('20120315220809');
+INSERT INTO public.schema_migrations (version) VALUES ('20120315220809');
 
-INSERT INTO schema_migrations (version) VALUES ('20120323105044');
+INSERT INTO public.schema_migrations (version) VALUES ('20120323105044');
 
-INSERT INTO schema_migrations (version) VALUES ('20120323115733');
+INSERT INTO public.schema_migrations (version) VALUES ('20120323115733');
 
-INSERT INTO schema_migrations (version) VALUES ('20120323181147');
+INSERT INTO public.schema_migrations (version) VALUES ('20120323181147');
 
-INSERT INTO schema_migrations (version) VALUES ('20120324025600');
+INSERT INTO public.schema_migrations (version) VALUES ('20120324025600');
 
-INSERT INTO schema_migrations (version) VALUES ('20120324094455');
+INSERT INTO public.schema_migrations (version) VALUES ('20120324094455');
 
-INSERT INTO schema_migrations (version) VALUES ('20120324100545');
+INSERT INTO public.schema_migrations (version) VALUES ('20120324100545');
 
-INSERT INTO schema_migrations (version) VALUES ('20120417190549');
+INSERT INTO public.schema_migrations (version) VALUES ('20120417190549');
 
-INSERT INTO schema_migrations (version) VALUES ('20120418231658');
+INSERT INTO public.schema_migrations (version) VALUES ('20120418231658');
 
-INSERT INTO schema_migrations (version) VALUES ('20120521225350');
+INSERT INTO public.schema_migrations (version) VALUES ('20120521225350');
 
-INSERT INTO schema_migrations (version) VALUES ('20120526101510');
+INSERT INTO public.schema_migrations (version) VALUES ('20120526101510');
 
-INSERT INTO schema_migrations (version) VALUES ('20120614160337');
+INSERT INTO public.schema_migrations (version) VALUES ('20120614160337');
 
-INSERT INTO schema_migrations (version) VALUES ('20120625212801');
+INSERT INTO public.schema_migrations (version) VALUES ('20120625212801');
 
-INSERT INTO schema_migrations (version) VALUES ('20130114094100');
+INSERT INTO public.schema_migrations (version) VALUES ('20130114094100');
 
-INSERT INTO schema_migrations (version) VALUES ('20130115032717');
+INSERT INTO public.schema_migrations (version) VALUES ('20130115032717');
 
-INSERT INTO schema_migrations (version) VALUES ('20130115042245');
+INSERT INTO public.schema_migrations (version) VALUES ('20130115042245');
 
-INSERT INTO schema_migrations (version) VALUES ('20130117110750');
+INSERT INTO public.schema_migrations (version) VALUES ('20130117110750');
 
-INSERT INTO schema_migrations (version) VALUES ('20130117110817');
+INSERT INTO public.schema_migrations (version) VALUES ('20130117110817');
 
-INSERT INTO schema_migrations (version) VALUES ('20130117111202');
+INSERT INTO public.schema_migrations (version) VALUES ('20130117111202');
 
-INSERT INTO schema_migrations (version) VALUES ('20130118064024');
+INSERT INTO public.schema_migrations (version) VALUES ('20130118064024');
 
-INSERT INTO schema_migrations (version) VALUES ('20130427160522');
+INSERT INTO public.schema_migrations (version) VALUES ('20130427160522');
 
-INSERT INTO schema_migrations (version) VALUES ('20130429205209');
+INSERT INTO public.schema_migrations (version) VALUES ('20130429205209');
 
-INSERT INTO schema_migrations (version) VALUES ('20130429205707');
+INSERT INTO public.schema_migrations (version) VALUES ('20130429205707');
 
-INSERT INTO schema_migrations (version) VALUES ('20130606042505');
+INSERT INTO public.schema_migrations (version) VALUES ('20130606042505');
 
-INSERT INTO schema_migrations (version) VALUES ('20130705092519');
+INSERT INTO public.schema_migrations (version) VALUES ('20130705092519');
 
-INSERT INTO schema_migrations (version) VALUES ('20140718095222');
+INSERT INTO public.schema_migrations (version) VALUES ('20140718095222');
 
-INSERT INTO schema_migrations (version) VALUES ('20150919060031');
+INSERT INTO public.schema_migrations (version) VALUES ('20150919060031');
 
-INSERT INTO schema_migrations (version) VALUES ('20160208190731');
+INSERT INTO public.schema_migrations (version) VALUES ('20160208190731');
 
-INSERT INTO schema_migrations (version) VALUES ('20160403092926');
+INSERT INTO public.schema_migrations (version) VALUES ('20160403092926');
 
-INSERT INTO schema_migrations (version) VALUES ('20160531111906');
+INSERT INTO public.schema_migrations (version) VALUES ('20160531111906');
 
-INSERT INTO schema_migrations (version) VALUES ('20160607005457');
+INSERT INTO public.schema_migrations (version) VALUES ('20160607005457');
 
-INSERT INTO schema_migrations (version) VALUES ('20160614042818');
+INSERT INTO public.schema_migrations (version) VALUES ('20160614042818');
 
-INSERT INTO schema_migrations (version) VALUES ('20160615215212');
+INSERT INTO public.schema_migrations (version) VALUES ('20160615215212');
 
-INSERT INTO schema_migrations (version) VALUES ('20180603015430');
+INSERT INTO public.schema_migrations (version) VALUES ('20180603015430');
 
-INSERT INTO schema_migrations (version) VALUES ('20181130044638');
+INSERT INTO public.schema_migrations (version) VALUES ('20181130044638');
 
-INSERT INTO schema_migrations (version) VALUES ('20191017054450');
+INSERT INTO public.schema_migrations (version) VALUES ('20191017054450');
 
-INSERT INTO schema_migrations (version) VALUES ('20191022080113');
+INSERT INTO public.schema_migrations (version) VALUES ('20191022080113');
 
-INSERT INTO schema_migrations (version) VALUES ('20191023060540');
+INSERT INTO public.schema_migrations (version) VALUES ('20191023060540');
 
-INSERT INTO schema_migrations (version) VALUES ('20191025034816');
+INSERT INTO public.schema_migrations (version) VALUES ('20191025034816');
 


### PR DESCRIPTION
### Before

I get error with `relation "schema_migrations" does not exist`.

```
$ docker-compose up -d
$ docker-compose exec -e 'DATABASE_URL=postgis://safecast:safecast@postgresql/safecast_development?schema_search_path=pubilc,postgis&encoding=unicode' app bundle exec rake db:drop db:create db:structure:load
...
psql:/src/db/structure.sql:1212: ERROR:  relation "schema_migrations" does not exist
LINE 1: INSERT INTO schema_migrations (version) VALUES ('20191023060...
                    ^
psql:/src/db/structure.sql:1214: ERROR:  relation "schema_migrations" does not exist
LINE 1: INSERT INTO schema_migrations (version) VALUES ('20191025034...
                    ^
GRANT
GRANT
```

### After

```
$ docker-compose up -d
$ docker-compose exec -e 'DATABASE_URL=postgis://safecast:safecast@postgresql/safecast_development?schema_search_path=public,postgis&encoding=unicode' app bundle exec rake db:drop db:create db:structure:load
...
INSERT 0 1
INSERT 0 1
GRANT
GRANT
```