### PR TITLE
Specify default platform in global config

### DIFF
--- a/.elasticbeanstalk/config.global.yml
+++ b/.elasticbeanstalk/config.global.yml
@@ -1,5 +1,6 @@
 global:
   application_name: api
+  default_platform: arn:aws:elasticbeanstalk:us-west-2::platform/Puma with Ruby 2.3 running on 64bit Amazon Linux/2.9.0
   default_ec2_keyname: safecastapi
   default_region: us-west-2
   profile: safecast


### PR DESCRIPTION
eb cli seems to require it now, though we don't use it since the eb helper determines it based on ruby version