### PR TITLE
Set LANG to en_US.UTF-8 in CircleCI container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
           RAILS_ENV: test
           AWS_DEFAULT_REGION: us-west-2
           EB_APP_NAME: api
+          LANG: en_US.UTF-8
       - image: mdillon/postgis:9.5
         environment:
           POSTGRES_USER: safecast
@@ -15,6 +16,10 @@ jobs:
       - image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
     steps:
       - checkout
+      - run:
+          name: Setup en_US.UTF-8
+          command: |
+            sudo localedef -i en_US -f UTF-8 en_US.UTF-8
       - run:
           name: Install build tools
           command: |

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,5 @@
 development:
+
   adapter: postgis
   schema_search_path: "public,postgis"
   script_dir: /usr/local/share/postgis
@@ -8,6 +9,8 @@ development:
   username: safecast
   su_username: safecast
   password:
+  host: postgresql
+  port: 5432
 
 test:
   adapter: postgis
@@ -20,6 +23,8 @@ test:
   su_username: safecast
   password:
   min_messages: warning
+  host: postgresql
+  port: 5432
 
 production:
   adapter: postgis

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 # XXX: Currently, this spec is for checking rails_admin gem installation.
 RSpec.describe RailsAdmin::MainController, 'login as admin', type: :controller do
   routes { RailsAdmin::Engine.routes }


### PR DESCRIPTION
To fix error in one of specs.

```
rspec ./spec/controllers/rails_admin/main_controller_spec.rb:82 # RailsAdmin::MainController login as user GET #dashboard should redirect to "/en-US"
```