### PR TITLE
Tune timing of export jobs

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -2,13 +2,13 @@ version: 1
 cron:
   - name: dump_clean
     url: /cron
-    schedule: "00 02 * * *"
+    schedule: "00 03 * * *"
   - name: dump_measurements
     url: /cron
-    schedule: "00 01 * * *"
+    schedule: "00 02 * * *"
   - name: dump_measurements_ios
     url: /cron
-    schedule: "33 */4 * * *"
+    schedule: "33 */8 * * *"
   - name: imbrogno_export
     url: /cron
     schedule: "00 02 * * 7"


### PR DESCRIPTION
They've been bunching up lately (see https://grafana.safecast.cc/d/W7c552kZz/api-overview). Running the ios export every 8 hours should be okay per @Frangible 

![image](https://user-images.githubusercontent.com/690/70489702-d645a700-1b3f-11ea-9d79-d7284648945c.png)


Also adjusting the timing of the other jobs should help avoid them running before dump_measurements_ios is finished.

