### PR TITLE
Remove deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'jquery-rails'
 gem 'json', '1.8.6'
 gem 'kaminari'
 gem 'newrelic_rpm'
-gem 'pg'
+gem 'pg', '0.20' # Unpin after upgrade to rails 5.x (per https://github.com/rails/rails/issues/29521#issuecomment-312088377)
 gem 'puma'
 gem 'rails_admin'
 gem 'responders'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       rails (>= 3.1)
     bootstrap-sass (2.2.2.0)
       sass (~> 3.2)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (11.0.1)
     cancan (1.6.10)
     capybara (3.29.0)
@@ -220,20 +220,20 @@ GEM
     multi_json (1.13.0)
     multipart-post (2.0.0)
     nested_form (0.3.2)
-    newrelic_rpm (3.12.1.298)
-    nokogiri (1.10.5)
+    newrelic_rpm (6.7.0.359)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.5-x64-mingw32)
+    nokogiri (1.10.7-x64-mingw32)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.5-x86-mingw32)
+    nokogiri (1.10.7-x86-mingw32)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
-    pg (0.21.0)
-    pg (0.21.0-x64-mingw32)
-    pg (0.21.0-x86-mingw32)
+    pg (0.20.0)
+    pg (0.20.0-x64-mingw32)
+    pg (0.20.0-x86-mingw32)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -350,9 +350,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    simple_form (3.2.1)
-      actionpack (> 4, < 5.1)
-      activemodel (> 4, < 5.1)
+    simple_form (4.0.0)
+      actionpack (> 4)
+      activemodel (> 4)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -422,7 +422,7 @@ DEPENDENCIES
   kaminari
   launchy
   newrelic_rpm
-  pg
+  pg (= 0.20)
   pry-byebug
   pry-rails
   puma

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,16 +1,17 @@
 <h2>Change your password</h2>
 
-<%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f| %>
-  <%= devise_error_messages! %>
-  <%= f.hidden_field :reset_password_token %>
+<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= f.error_notification %>
 
-  <div><%= f.label :password, "New password" %><br />
-  <%= f.password_field :password %></div>
+  <%= f.input :reset_password_token, as: :hidden %>
+  <%= f.full_error :reset_password_token %>
 
-  <div><%= f.label :password_confirmation, "Confirm new password" %><br />
-  <%= f.password_field :password_confirmation %></div>
+  <%= f.input :password, label: "New password", required: true %>
+  <%= f.input :password_confirmation, label: "Confirm new password", required: true %>
 
-  <div><%= f.submit "Change my password" %></div>
+  <div class="form-actions">
+    <%= f.button :submit, "Change my password" %>
+  </div>
 <% end %>
 
 <%= render 'devise/shared/links' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,12 +1,13 @@
 <h2>Forgot your password?</h2>
 
-<%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f| %>
-  <%= devise_error_messages! %>
+<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
 
-  <div><%= f.label :email %><br />
-  <%= f.email_field :email %></div>
+  <%= f.input :email, required: true %>
 
-  <div><%= f.submit "Send me reset password instructions" %></div>
+  <div class="form-actions">
+    <%= f.button :submit, "Send me reset password instructions" %>
+  </div>
 <% end %>
 
-<%= render 'devise/shared/links' %>
+<%= render "devise/shared/links" %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Safecast::Application.configure do
   config.cache_classes = false
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching

--- a/lib/tasks/pending_imports_reminder.thor
+++ b/lib/tasks/pending_imports_reminder.thor
@@ -7,7 +7,7 @@ class PendingImportsReminder < Thor
 
     users = User.where(id: BgeigieImport.pending.group(:user_id).pluck(:user_id))
     users.each do |user|
-      Reminders.pending_imports(user).deliver
+      Reminders.pending_imports(user).deliver_now
     end
   end
 end


### PR DESCRIPTION
Newrelic - bundle update (for fixnum deprecation)

Simpleform - bundle update (for fixnum deprecation)

Pg - locked to 0.20 to avoid PGError warnings. Should upgrade when we get to Rails 5.x

Devise views, switched password edit & new to use simple form to avoid use of deprecated devise errors helper. Initially tried full view generation but led to a mess of errors on expected strings no longer being present.

Deliver warning, switched code

Static asset warning, switched code

Should look something like this now

![Screen Shot 2019-12-13 at 5 26 37 PM](https://user-images.githubusercontent.com/690/70785350-c80cba80-1dcd-11ea-8140-87b8b53471ab.png)

