### PR TITLE
Expanded all elastic beanstalk root disks to 32 GB and fixed a bug in…

### DIFF
--- a/.ebextensions/00-expand-root-disk.config
+++ b/.ebextensions/00-expand-root-disk.config
@@ -1,0 +1,10 @@
+---
+Resources:
+  AWSEBAutoScalingLaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize:
+              32

--- a/lib/elasticbeanstalk_helper.rb
+++ b/lib/elasticbeanstalk_helper.rb
@@ -7,7 +7,7 @@ class ElasticBeanstalkHelper
   attr_reader :application_name, :environment_prefix, :environment_config
 
   def initialize(application_name, environment_prefix, environment_config = nil)
-    if environment_config == nil
+    if environment_config.nil?
       environment_config = (ENV['AWS_EB_CFG'] || 'dev')
     end
 

--- a/lib/elasticbeanstalk_helper.rb
+++ b/lib/elasticbeanstalk_helper.rb
@@ -6,7 +6,11 @@ class ElasticBeanstalkHelper
   attr_reader :elasticbeanstalk
   attr_reader :application_name, :environment_prefix, :environment_config
 
-  def initialize(application_name, environment_prefix, environment_config = ENV['AWS_EB_CFG'] || 'dev')
+  def initialize(application_name, environment_prefix, environment_config = nil)
+    if environment_config == nil
+      environment_config = (ENV['AWS_EB_CFG'] || 'dev')
+    end
+
     @application_name = application_name
     @environment_prefix = environment_prefix
     @environment_config = environment_config


### PR DESCRIPTION
… the `elasticbeanstalk_helper`.

This should give us plenty of disk space. However, it does so on both the web and worker tier. I see that there's a `workers.config` but I'm not sure how that gets targeted to the workers specifically, and also if we can target dev-wrk and prd-wrk separately, since prd probably needs more disk space.

I've selectively used this code already to expand the worker nodes, but before we merge it I think we should take a look and see if we can improve it to that end.

Also worth noting that I didn't have any luck expanding the disk size by modifying the EB config files and updating existing environments, then destroying/re-creating nodes. I'm not sure if it would've worked if I created an entirely new environment; however, it's probably better to put it in `.ebextensions` anyway so it's version controlled.