### PR TITLE
Fix a default locate switcher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,10 @@ jobs:
           command: |
             bundle exec rubocop
       - run:
+          name: Run assets precompile
+          command: |
+            bundle exec rake assets:precompile
+      - run:
           name: Run rspec
           command: |
             bundle exec rspec --profile 10 \

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ log/localeapp.yml
 .env
 .envrc
 .direnv
+.byebug_history
 
 .elasticbeanstalk/config.yml
 .elasticbeanstalk/app_versions/

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   def link_to_switch_locale
-    if params[:locale] == 'en-US'
+    if I18n.locale == :'en-US'
       link_to 'JA', locale: 'ja'
     else
       link_to 'EN', locale: 'en-US'


### PR DESCRIPTION
When loading a home page for the first time it defaults to `EN` while it should be `JP` because the default is `EN`