### PR TITLE
Enable elastic_apm for prod only

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Safecast
   class Application < Rails::Application
     config.load_defaults 5.2
     config.active_record.belongs_to_required_by_default = false
+    config.elastic_apm.active = Rails.env.production?
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module Safecast
   class Application < Rails::Application
     config.load_defaults 5.2
     config.active_record.belongs_to_required_by_default = false
-    config.elastic_apm.active = Rails.env.production?
+    config.elastic_apm.active = ENV['ELASTIC_APM_SECRET_TOKEN'].present?
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
Currently, dev environment shows errors in the log that was introduced after adding `elastic-apm` gem (https://github.com/Safecast/safecastapi/pull/662):
```
app_1            | [ElasticAPM] Couldn't establish connection to APM Server:
app_1            | "#<HTTP::ConnectionError: failed to connect: Cannot assign requested address - connect(2) for \"localhost\" port 8200>"
app_1            | [ElasticAPM] Couldn't establish connection to APM Server:
app_1            | "#<HTTP::ConnectionError: failed to connect: Cannot assign requested address - connect(2) for \"localhost\" port 8200>"
app_1            | [ElasticAPM] Couldn't establish connection to APM Server:
app_1            | "#<HTTP::ConnectionError: failed to connect: Cannot assign requested address - connect(2) for \"localhost\" port 8200>"
app_1            | [ElasticAPM] Couldn't establish connection to APM Server:
app_1            | "#<HTTP::ConnectionError: failed to connect: Cannot assign requested address - connect(2) for \"localhost\" port 8200>"
app_1            | [ElasticAPM] Couldn't establish connection to APM Server:
app_1            | "#<HTTP::ConnectionError: failed to connect: Cannot assign requested address - connect(2) for \"localhost\" port 8200>"
app_1            | [ElasticAPM] Couldn't establish connection to APM Server:
app_1            | "#<HTTP::ConnectionError: failed to connect: Cannot assign requested address - connect(2) for \"localhost\" port 8200>"
app_1            | [ElasticAPM] Couldn't establish connection to APM Server:
app_1            | "#<HTTP::ConnectionError: failed to connect: Cannot assign requested address - connect(2) for \"localhost\" port 8200>"
```

Let's enabled for production environment only: https://github.com/elastic/apm-agent-ruby/blob/eab38ab986636c465a54e523144b32d63fa1f49a/docs/configuration.asciidoc#active-deprecated370see-enabled-instead