### PR TITLE
Use counter_cache

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -40,14 +40,14 @@
       <li>
         <%= link_to [:measurements] do %>
           <em>
-            <%= number_with_delimiter current_user.measurements.count %>
+            <%= number_with_delimiter current_user.measurements.size %>
           </em>
           <%= t('.submissions') %>
         <%- end -%>
       </li>
       <li>
         <%= link_to [:bgeigie_imports] do %>
-          <em><%= current_user.bgeigie_imports.count  %></em>
+          <em><%= current_user.bgeigie_imports.size  %></em>
           <%= t('.bgeigie_imports') -%>
         <%- end -%>
       </li>


### PR DESCRIPTION
`counter_cache` wasn't really used in the right place. Instead of using `#count`, it should be `#size` (or use `#measurements_count` directly) to avoid additional `SQL`
https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-counter-cache
```
[13] pry(main)> User.first.measurements.count
  User Load (0.8ms)  SELECT  "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
   (9.5ms)  SELECT COUNT(*) FROM "measurements" WHERE "measurements"."user_id" = $1  [["user_id", 1]]
=> 46383
[14] pry(main)> User.first.measurements.size
  User Load (0.5ms)  SELECT  "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> 46383
```
@eitoball I saw you just closed your PR (https://github.com/Safecast/safecastapi/pull/556). Do you have time to review?  Ref #547 