### PR TITLE
Switch elastic apm activation strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'devise-i18n'
 gem 'devise-token_authenticatable'
 gem 'dotenv-rails'
 gem 'draper'
-gem 'elastic-apm'
 gem 'elasticsearch-model'
 gem 'fog-aws', '~> 2.0.0'
 gem 'formatted-dates'
@@ -45,6 +44,10 @@ gem 'swagger-blocks'
 # noinspection RailsParamDefResolve
 gem 'tzinfo-data', platforms: %i(mingw mswin x64_mingw)
 gem 'uglifier'
+
+group :production do
+  gem 'elastic-apm'
+end
 
 group :development do
   gem 'pry-byebug', group: :test

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,6 @@ module Safecast
   class Application < Rails::Application
     config.load_defaults 5.2
     config.active_record.belongs_to_required_by_default = false
-    config.elastic_apm.active = ENV['ELASTIC_APM_SECRET_TOKEN'].present?
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
This seems like the better option to avoid enabling it in dev environments while not using the deprecated `config.elastic_apm.active=`