### PR TITLE
Remove explicit usage of RAILS_ENV

### DIFF
--- a/bin/run_tests.bash
+++ b/bin/run_tests.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose run --rm --entrypoint bash -c "RAILS_ENV='test' bundle exec rspec spec" app
+docker-compose run --rm --entrypoint bash -c "bundle exec rspec spec" app

--- a/bin/run_tests.bash
+++ b/bin/run_tests.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose run app bash -c "bundle exec rspec spec" --rm --entrypoint
+docker-compose run --rm app bash -c "bundle exec rspec spec"

--- a/bin/run_tests.bash
+++ b/bin/run_tests.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose run --rm --entrypoint bash -c "bundle exec rspec spec" app
+docker-compose run app bash -c "bundle exec rspec spec" --rm --entrypoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     environment:
       DATABASE_HOST: 'postgresql'
       ELASTICSEARCH_URL: 'http://elasticsearch:9200'
-      RAILS_ENV: 'development'
     volumes:
       - .:/src
     depends_on:

--- a/docker_bin/run_test.bash
+++ b/docker_bin/run_test.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-RAILS_ENV='test' bundle exec rspec "$@"
+bundle exec rspec "$@"


### PR DESCRIPTION
Default `RAILS_ENV` was added to [docker-compose](https://github.com/Safecast/safecastapi/blob/master/docker-compose.yml#L13) file and `rspec` was [running](https://github.com/Safecast/safecastapi/blob/master/spec/spec_helper.rb#L13) in `development` env. I assume this is why `RAILS_ENV` was [injected](https://github.com/Safecast/safecastapi/blob/master/docker_bin/run_test.bash#L3).

I think it makes sense to let `spec_helper.rb` set `RAILS_ENV`. 

What do you think? 