### PR TITLE
Fix Missing host to links

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -69,7 +70,14 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.delivery_method = :aws_sdk
+
+  config.action_mailer.default_url_options = {
+    host: ENV['DEFAULT_HOSTNAME'] || 'api.safecast.org',
+    protocol: 'https'
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -96,3 +104,4 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Bringing back configs that were [accidentally removed](https://github.com/Safecast/safecastapi/commit/d73d3ceb87aa1350509e0c9a5d83a2a7231bcae3#diff-1d98f0039bbc6df92adee882ed99d993L67-L70) while upgrading to Rails 5.