### PR TITLE
Fix init databases

### DIFF
--- a/bin/initialize_databases.bash
+++ b/bin/initialize_databases.bash
@@ -5,14 +5,10 @@ base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd -P )"
 cd "$base_dir"/..
 
 # In some situations the Postgres container may not have started completely yet
-docker-compose run app bash -c "sleep 10 && bundle exec rake db:environment:set RAILS_ENV=development"
-docker-compose run app bundle exec rake db:drop db:create db:structure:load
-docker-compose run app bundle exec rake db:bootstrap
-
+docker-compose run app bash -c "sleep 10 && bundle exec rake db:environment:set RAILS_ENV=development && bundle exec rake db:drop db:create db:structure:load && bundle exec rake db:bootstrap"
 
 # Note that we don't use `db:test:prepare` here but instead use
 # create/load under both the development and test environment. This is
 # due to our use of postgis and structure.sql (as opposed to
 # schema.rb).
-docker-compose run app bash -c "RAILS_ENV='test' bundle exec rake db:environment:set RAILS_ENV=test"
-docker-compose run app bash -c "RAILS_ENV='test' bundle exec rake db:drop db:create db:structure:load"
+docker-compose run app bash -c "RAILS_ENV='test' bundle exec rake db:environment:set RAILS_ENV=test && bundle exec rake db:drop db:create db:structure:load"

--- a/bin/initialize_databases.bash
+++ b/bin/initialize_databases.bash
@@ -4,6 +4,8 @@ base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd -P )"
 
 cd "$base_dir"/..
 
+# In some situations the Postgres container may not have started completely yet
+docker-compose run app bash -c "sleep 10 && bundle exec rake db:environment:set RAILS_ENV=development"
 docker-compose run app bundle exec rake db:drop db:create db:structure:load
 docker-compose run app bundle exec rake db:bootstrap
 
@@ -12,4 +14,5 @@ docker-compose run app bundle exec rake db:bootstrap
 # create/load under both the development and test environment. This is
 # due to our use of postgis and structure.sql (as opposed to
 # schema.rb).
+docker-compose run app bash -c "RAILS_ENV='test' bundle exec rake db:environment:set RAILS_ENV=test"
 docker-compose run app bash -c "RAILS_ENV='test' bundle exec rake db:drop db:create db:structure:load"

--- a/bin/initialize_databases.bash
+++ b/bin/initialize_databases.bash
@@ -4,11 +4,13 @@ base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd -P )"
 
 cd "$base_dir"/..
 
+set -o xtrace
+
 # In some situations the Postgres container may not have started completely yet
-docker-compose run app bash -c "sleep 10 && bundle exec rake db:environment:set RAILS_ENV=development && bundle exec rake db:drop db:create db:structure:load && bundle exec rake db:bootstrap"
+docker-compose run app bash -c "sleep 10 && RAILS_ENV=development bundle exec rake db:environment:set RAILS_ENV=development && RAILS_ENV=development bundle exec rake db:drop db:create db:structure:load && RAILS_ENV=development bundle exec rake db:bootstrap"
 
 # Note that we don't use `db:test:prepare` here but instead use
 # create/load under both the development and test environment. This is
 # due to our use of postgis and structure.sql (as opposed to
 # schema.rb).
-docker-compose run app bash -c "RAILS_ENV='test' bundle exec rake db:environment:set RAILS_ENV=test && bundle exec rake db:drop db:create db:structure:load"
+docker-compose run app bash -c "RAILS_ENV='test' bundle exec rake db:environment:set RAILS_ENV=test && RAILS_ENV='test' bundle exec rake db:drop db:create db:structure:load"


### PR DESCRIPTION
In some situations, the script would not work because `db:environment:set` was not being invoked.