### PR TITLE
Added git tagging of builds.

### DIFF
--- a/.elasticbeanstalk/package.sh
+++ b/.elasticbeanstalk/package.sh
@@ -28,6 +28,9 @@ VERSION="${EB_APP_NAME}-${CLEAN_BRANCH_NAME}-${BUILD_NUMBER}"
 
 PACKAGE="${VERSION}.zip"
 
+git tag "$VERSION"
+git push origin "$VERSION"
+
 cp config/database.yml.beanstalk config/database.yml
 
 .elasticbeanstalk/package.py "${PACKAGE}"


### PR DESCRIPTION
If we do this, it will become much easier to generate diffs of what has changed between deploys.

We will need to grant CircleCI write privs on our repositories, however.