### PR TITLE
Moved approved/rejected information from bgeigie listing to show page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -5,3 +5,10 @@
  *= require application/safecast
  *= require bootstrap-datetimepicker.min
 */
+
+span {
+    color:#202020;
+    font-size: 13px;
+    font-family: proxima-nova, 
+    sans-serif;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -6,9 +6,8 @@
  *= require bootstrap-datetimepicker.min
 */
 
-span {
-    color:#202020;
-    font-size: 13px;
-    font-family: proxima-nova, 
-    sans-serif;
+.status-text {
+  color:#202020;
+  font-size: 13px;
+  font-family: proxima-nova, sans-serif;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -7,7 +7,7 @@
 */
 
 .status-text {
-  color:#202020;
+  color: #202020;
   font-size: 13px;
   font-family: proxima-nova, sans-serif;
 }

--- a/app/helpers/bgeigie_imports_helper.rb
+++ b/app/helpers/bgeigie_imports_helper.rb
@@ -46,8 +46,8 @@ module BgeigieImportsHelper
     user.try!(:moderator?)
   end
 
-  def approval_participant?(user, bgeigie_import)
-    user.moderator? || user == bgeigie_import.user
+  def approval_participant?(bgeigie_import)
+    current_user.moderator? || current_user == bgeigie_import.user
   end
 
   def tilemap_link(bgeigie_import)

--- a/app/helpers/bgeigie_imports_helper.rb
+++ b/app/helpers/bgeigie_imports_helper.rb
@@ -46,6 +46,10 @@ module BgeigieImportsHelper
     user.try!(:moderator?)
   end
 
+  def approval_participant?(user, bgeigie_import)
+    user.moderator? || user == bgeigie_import.user
+  end
+
   def tilemap_link(bgeigie_import)
     link_to 'Map View', "https://safecast.org/tilemap/?logids=#{bgeigie_import.id}", target: '_blank', class: 'btn btn-primary', style: 'color: #fff'
   end

--- a/app/views/bgeigie_imports/_status.html.erb
+++ b/app/views/bgeigie_imports/_status.html.erb
@@ -11,13 +11,20 @@
     <%= @bgeigie_import.status.humanize %>
   </span>
 <%- end -%>
-<%- if @bgeigie_import.rejected == true -%>
-  <span class="label label-warning">
-    Rejected by: <%= @bgeigie_import.rejected_by %>
-  </span><span style="color: #202020;font-size: 13px;font-family: proxima-nova, sans-serif;">
-  <b>comment:</b>
-  <%= @bgeigie_import.comment if @bgeigie_import.comment.present? %>
-</span>
+<%- if user_signed_in? && (current_user.moderator? || current_user == @bgeigie_import.user)-%>
+  <%- if @bgeigie_import.rejected? -%>
+    <span class="label label-warning">
+      Rejected by: <%= @bgeigie_import.rejected_by %>
+    </span>
+    <span style="color: #202020;font-size: 13px;font-family: proxima-nova, sans-serif;">
+      <b>comment:</b>
+      <%= @bgeigie_import.comment if @bgeigie_import.comment.present? %>
+    </span>
+  <%- elsif @bgeigie_import.approved? -%>
+    <span class="label label-success">
+      Approved by: <%= @bgeigie_import.approved_by %>
+    </span>
+  <%- end -%>
 <%- end -%>
 <%- if !@bgeigie_import.rejected? && @bgeigie_import.awaiting_approval? && user_signed_in? && current_user.moderator? -%>
 <span style="color: #202020;font-size: 13px; font-family: proxima-nova, sans-serif;">

--- a/app/views/bgeigie_imports/_status.html.erb
+++ b/app/views/bgeigie_imports/_status.html.erb
@@ -1,4 +1,3 @@
-<%= stylesheet_link_tag "application.css" %>
 <%- if @bgeigie_import.status == 'done' -%>
   <span class="label label-success">
     <%= t('.processed') -%>
@@ -17,7 +16,7 @@
     <span class="label label-warning">
       Rejected by: <%= @bgeigie_import.rejected_by %>
     </span>
-    <span>
+    <span class="status-text">
       <b>comment:</b>
       <%= @bgeigie_import.comment if @bgeigie_import.comment.present? %>
     </span>
@@ -28,5 +27,5 @@
   <%- end -%>
 <%- end -%>
 <%- if !@bgeigie_import.rejected? && @bgeigie_import.awaiting_approval? && user_signed_in? && current_user.moderator? -%>
-<span>If rejecting, please enter a comment in Metadata.</span>
+<span class="status-text">If rejecting, please enter a comment in Metadata.</span>
 <%- end -%>

--- a/app/views/bgeigie_imports/_status.html.erb
+++ b/app/views/bgeigie_imports/_status.html.erb
@@ -11,7 +11,7 @@
     <%= @bgeigie_import.status.humanize %>
   </span>
 <%- end -%>
-<%- if user_signed_in? && approval_participant?(current_user, @bgeigie_import)-%>
+<%- if user_signed_in? && approval_participant?(@bgeigie_import)-%>
   <%- if @bgeigie_import.rejected? -%>
     <span class="label label-warning">
       Rejected by: <%= @bgeigie_import.rejected_by %>

--- a/app/views/bgeigie_imports/_status.html.erb
+++ b/app/views/bgeigie_imports/_status.html.erb
@@ -11,7 +11,7 @@
     <%= @bgeigie_import.status.humanize %>
   </span>
 <%- end -%>
-<%- if user_signed_in? && (current_user.moderator? || current_user == @bgeigie_import.user)-%>
+<%- if user_signed_in? && approval_participant?(current_user, @bgeigie_import)-%>
   <%- if @bgeigie_import.rejected? -%>
     <span class="label label-warning">
       Rejected by: <%= @bgeigie_import.rejected_by %>

--- a/app/views/bgeigie_imports/_status.html.erb
+++ b/app/views/bgeigie_imports/_status.html.erb
@@ -1,3 +1,4 @@
+<%= stylesheet_link_tag "application.css" %>
 <%- if @bgeigie_import.status == 'done' -%>
   <span class="label label-success">
     <%= t('.processed') -%>
@@ -16,7 +17,7 @@
     <span class="label label-warning">
       Rejected by: <%= @bgeigie_import.rejected_by %>
     </span>
-    <span style="color: #202020;font-size: 13px;font-family: proxima-nova, sans-serif;">
+    <span>
       <b>comment:</b>
       <%= @bgeigie_import.comment if @bgeigie_import.comment.present? %>
     </span>
@@ -27,6 +28,5 @@
   <%- end -%>
 <%- end -%>
 <%- if !@bgeigie_import.rejected? && @bgeigie_import.awaiting_approval? && user_signed_in? && current_user.moderator? -%>
-<span style="color: #202020;font-size: 13px; font-family: proxima-nova, sans-serif;">
-If rejecting, please enter a comment in Metadata.</span>
+<span>If rejecting, please enter a comment in Metadata.</span>
 <%- end -%>

--- a/app/views/bgeigie_imports/index.html.erb
+++ b/app/views/bgeigie_imports/index.html.erb
@@ -57,8 +57,6 @@
       <%= table_sort_header(:bgeigie_import, :source) %>
       <%= table_sort_header(:bgeigie_import, :measurements_count) %>
       <%= table_sort_header(:bgeigie_import, :status) %>
-      <%= table_sort_header(:bgeigie_import, :rejected_by) %>
-      <%= table_sort_header(:bgeigie_import, :approved_by) %>
       <%= table_sort_header(:bgeigie_import, :comments) %>
     </thead>
     <tbody>
@@ -108,12 +106,6 @@
             <%- if bgeigie_import.rejected? -%>
               <span class="notapproved">(<%= t("bgeigie_imports.states.rejected") %>)</span>
             <%- end -%>
-          </td>
-          <td>
-            <%= bgeigie_import.rejected_by %>
-          </td>
-          <td>
-            <%=bgeigie_import.approved_by %>
           </td>
           <td>
             <%=bgeigie_import.comment %>


### PR DESCRIPTION
fixes #536 
Removed approved by/rejected by columns from table on bgeigie listing page. Approved/rejected information is on show page and is only viewable by moderators and uploader. 