### PR TITLE
Remove duplicated option settings in .ebextensions

### DIFF
--- a/.ebextensions/aws.config
+++ b/.ebextensions/aws.config
@@ -1,8 +1,3 @@
-option_settings:
-  - namespace: aws:elb:policies
-    option_name: ConnectionSettingIdleTimeout
-    value: 300
-
 files:
   "/etc/profile.d/z_environment.sh" :
     content: |


### PR DESCRIPTION
I would like to remove this because the same option setting (`ConnectionSettingIdleTimeout`) is in `.ebextensions/web.config`. 