### PR TITLE
Allowed user overrides of exposed docker-compose ports.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:${SC_API_WEB_PORT:-3000}:3000"
     environment:
       DATABASE_HOST: 'postgresql'
       ELASTICSEARCH_URL: 'http://elasticsearch:9200'
@@ -22,7 +22,7 @@ services:
     environment:
       discovery.type: single-node
     ports:
-      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:${SC_API_ELASTIC_PORT:-9200}:9200"
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
   postgresql:
@@ -30,7 +30,7 @@ services:
       context: .
       dockerfile: Dockerfile.postgres
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${SC_API_POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
 


### PR DESCRIPTION
When using docker-compose for development, some people (including me) were seeing port conflicts between Postgres servers already running on the host and the ports exposed by docker-compose for debugging.

With this change, you can set environment variables to override the ports.

Before accepting the PR, I should also update the documentation in https://github.com/Safecast/safecastapi/wiki/Dev:-Setup-on-Linux-and-OS-X-using-Docker