### PR TITLE
Added real IP and block IP functionality.

### DIFF
--- a/.ebextensions/web.config
+++ b/.ebextensions/web.config
@@ -7,7 +7,7 @@ files:
   "/etc/nginx/conf.d/proxy.conf":
     content: |
       client_max_body_size 10M;
-  "/etc/nginx/default.d/blockips.conf":
+  "/etc/nginx/conf.d/blockips.conf":
     content: |
       deny 104.160.37.205;
       deny 13.56.21.188;
@@ -15,7 +15,7 @@ files:
       deny 47.240.44.214;
       deny 5.101.0.209;
       deny 88.230.96.236;
-  "/etc/nginx/default.d/realip.conf":
+  "/etc/nginx/conf.d/realip.conf":
     content: |
       real_ip_header X-Forwarded-For;
       real_ip_recursive on;

--- a/.ebextensions/web.config
+++ b/.ebextensions/web.config
@@ -4,9 +4,22 @@ option_settings:
     value: 600
 
 files:
-  "/etc/nginx/conf.d/proxy.conf" :
+  "/etc/nginx/conf.d/proxy.conf":
     content: |
       client_max_body_size 10M;
+  "/etc/nginx/default.d/blockips.conf":
+    content: |
+      deny 104.160.37.205;
+      deny 13.56.21.188;
+      deny 185.28.249.190;
+      deny 47.240.44.214;
+      deny 5.101.0.209;
+      deny 88.230.96.236;
+  "/etc/nginx/default.d/realip.conf":
+    content: |
+      real_ip_header X-Forwarded-For;
+      real_ip_recursive on;
+      set_real_ip_from 172.31.0.0/16;
 
 commands:
   match_nginx_timeout_to_elb_timeout:


### PR DESCRIPTION
Related to issue #648 

Based on research from @ZacharyCChang0828 

This will enable us to block IP addresses or CIDR ranges by modifying the `web.config` file and redeploying.

I have manually applied these changes in dev, so I know that the config works, but I'm not sure the `.ebextensions` syntax is correct.

Risks:
* Listing these IP address publicly could theoretically aid an attacker, but I'm not sure how.
* Using the real_ip module will change our logs; the AWS load balancer IP address will no longer show up in them. Instead, the request IP address will be the real one.

Follow-up tasks:
* We need to review and document what steps need to be taken to deploy an `.ebextensions` change. I'm not sure an ordinary deploy will do it.
* We should make the same changes to ingest.