### PR TITLE
Fix not to cache script content for chromium-base browsers

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,9 +29,9 @@ searchBox.keyup(
     var input = $(this);
     var newValue = input.val();
     if (searchBoxValue !== newValue) {
-      input.submit();
+      this.form.submit();
       var state = $(this.form).serializeArray();
-      history.pushState({}, "", "?" + $.param(state));
+      history.pushState({}, document.title, "?" + $.param(state));
     }
     searchBoxValue = newValue;
   }, 200)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,18 +21,17 @@ jQuery.ajaxSetup({
   }
 });
 
-var searchBox = $("#search_form form input[type=search]");
-var searchBoxValue = searchBox.val();
+var searchForm = document.querySelector("#search_form form");
+if (searchForm) {
+  searchForm.addEventListener("ajax:beforeSend", function () {
+    var state = $(searchForm).serializeArray();
+    history.pushState({}, document.title, "?" + $.param(state));
+  });
 
-searchBox.keyup(
-  _.debounce(function() {
-    var input = $(this);
-    var newValue = input.val();
-    if (searchBoxValue !== newValue) {
-      this.form.submit();
-      var state = $(this.form).serializeArray();
-      history.pushState({}, document.title, "?" + $.param(state));
-    }
-    searchBoxValue = newValue;
-  }, 200)
-);
+  var searchBox = searchForm.querySelector("input[type=search]");
+  if (searchBox) {
+    searchBox.addEventListener("input", _.debounce(function () {
+      searchForm.submit();
+    }, 200));
+  }
+}

--- a/app/views/device_stories/_search_form.html.erb
+++ b/app/views/device_stories/_search_form.html.erb
@@ -1,5 +1,5 @@
-<%= form_tag(device_stories_path, remote: true, :method => "get", enforce_utf8: false,
-             class: 'navbar-form navbar-left') do %>
+<%= form_tag(device_stories_path, remote: true, method: :get, enforce_utf8: false,
+             class: 'navbar-form navbar-left', data: { type: 'script' }) do %>
   <%= hidden_field_tag :fullscr, params[:fullscr] %>
   <%= hidden_field_tag :per_page, params[:per_page] %>
   <div class="input-group">


### PR DESCRIPTION
Fixes #746

This occurs in Google Chrome and MicroSoft Edge, I think. It is because those browsers caches script contents, and they associate cached contents with histories.