### PR TITLE
Mobile friendly Airnote device story page

### DIFF
--- a/app/controllers/device_stories_controller.rb
+++ b/app/controllers/device_stories_controller.rb
@@ -21,6 +21,11 @@ class DeviceStoriesController < ApplicationController
     respond_with @device_story
   end
 
+  def show_mobile
+    @device_story = DeviceStory.where(device_urn: params[:device_urn]).first
+    respond_with @device_story
+  end
+
   def get_like_searched_table(search_term)
     apply_scopes(DeviceStory).where('lower(device_urn) LIKE :search OR lower(custodian_name) LIKE :search', search: "%#{search_term}%")
       .or(apply_scopes(DeviceStory).where('lower(last_values) LIKE :search OR lower(last_location_name) LIKE :search', search: "%#{search_term}%"))
@@ -31,6 +36,8 @@ class DeviceStoriesController < ApplicationController
 
   def current_layout
     if params[:fullscr] == 'true'
+      'full_width_device_stories'
+    elsif !params[:device_urn].blank?
       'full_width_device_stories'
     else
       'application'

--- a/app/helpers/device_stories_helper.rb
+++ b/app/helpers/device_stories_helper.rb
@@ -4,13 +4,19 @@ module DeviceStoriesHelper
   def grafana_panel(name)
     panels = {
       cpm: 14,
-      map: 8
+      map: 8,
+      air_quality: 15,
+      air_quality_map: 21
     }
     panels[name]
   end
 
-  def grafana_url(variant = nil)
-    url = ENV['DEVICE_STORIES_GRAFANA_BASE_URL'] || 'https://grafana.safecast.cc/d/DFSxrOLWk/safecast-device-details'
+  def grafana_url(variant = nil, is_airnote = false)
+    if is_airnote
+      url = ENV['DEVICE_STORIES_GRAFANA_BASE_URL'] || 'https://grafana.safecast.cc/d/7wsttvxGk/safecast-airnote'
+    else
+      url = ENV['DEVICE_STORIES_GRAFANA_BASE_URL'] || 'https://grafana.safecast.cc/d/DFSxrOLWk/safecast-device-details'
+    end
     uri = URI.parse(url)
     if variant == :solo
       parts = uri.path.split('/')
@@ -20,8 +26,8 @@ module DeviceStoriesHelper
     uri
   end
 
-  def grafana_more_data(device_urn)
-    url = grafana_url
+  def grafana_more_data(device_urn, is_airnote = false)
+    url = grafana_url(nil, is_airnote)
     args = {
       from: 'now-90d',
       to: 'now',
@@ -32,8 +38,8 @@ module DeviceStoriesHelper
     url.to_s.html_safe
   end
 
-  def grafana_iframe(device_urn, panel_id)
-    url = grafana_url(:solo)
+  def grafana_iframe(device_urn, panel_id, is_airnote = false )
+    url = grafana_url(:solo, is_airnote)
     args = {
       from: 'now-90d',
       to: 'now',

--- a/app/helpers/device_stories_helper.rb
+++ b/app/helpers/device_stories_helper.rb
@@ -12,11 +12,8 @@ module DeviceStoriesHelper
   end
 
   def grafana_url(variant = nil, is_airnote = false)
-    if is_airnote
-      url = ENV['DEVICE_STORIES_GRAFANA_BASE_URL'] || 'https://grafana.safecast.cc/d/7wsttvxGk/safecast-airnote'
-    else
-      url = ENV['DEVICE_STORIES_GRAFANA_BASE_URL'] || 'https://grafana.safecast.cc/d/DFSxrOLWk/safecast-device-details'
-    end
+    url = if is_airnote then ENV['DEVICE_STORIES_GRAFANA_BASE_URL'] || 'https://grafana.safecast.cc/d/7wsttvxGk/safecast-airnote'
+          else ENV['DEVICE_STORIES_GRAFANA_BASE_URL'] || 'https://grafana.safecast.cc/d/DFSxrOLWk/safecast-device-details' end
     uri = URI.parse(url)
     if variant == :solo
       parts = uri.path.split('/')
@@ -38,7 +35,7 @@ module DeviceStoriesHelper
     url.to_s.html_safe
   end
 
-  def grafana_iframe(device_urn, panel_id, is_airnote = false )
+  def grafana_iframe(device_urn, panel_id, is_airnote = false)
     url = grafana_url(:solo, is_airnote)
     args = {
       from: 'now-90d',

--- a/app/views/device_stories/_help_page.html.erb
+++ b/app/views/device_stories/_help_page.html.erb
@@ -1,0 +1,1 @@
+Invalid URN. Help page is work in progress.

--- a/app/views/device_stories/show_mobile.html.erb
+++ b/app/views/device_stories/show_mobile.html.erb
@@ -3,7 +3,7 @@ Invalid URN. Help page is work in progress.
 <%- else %>
   <%= content_for(:title) do %>
   <%- end -%>
-  <div style="margin-left: 10px">
+  <div style="margin-left: 10px; text-align: center">
     <h2>
     <%= @device_story.last_location_name %> (<%= @device_story.device_urn %>)
     <%- if  @device_story.last_seen %>
@@ -11,9 +11,10 @@ Invalid URN. Help page is work in progress.
     <%- end %>
     </h2>
   </div>
-  <div class="" style="display: flex; flex-wrap: wrap; justify-content: space-evenly;">
-    <div style="max-width: 155px">
-      <table class="table table-hover" style="margin-left: auto; margin-right: auto; min-width: 164px; table-layout: auto; margin-top: 10%; word-wrap: break-word">
+  <hr>
+  <div class="" style="display: flex; flex-wrap: wrap; justify-content: space-around;">
+    <div style="max-width: 155px; margin-bottom: 50px">
+      <table class="table table-hover" style="margin-left: auto; margin-right: auto; min-width: 164px; table-layout: fixed; margin-top: 10%; word-wrap: break-word">
         <thead style="font-size: 13px">
         <tr>
           <td colspan="3" style="text-align:center"><%= @device_story.last_seen %></td>
@@ -34,13 +35,14 @@ Invalid URN. Help page is work in progress.
           </td>
         </tr>
       </table>
-      <button type="button" style="  display: flex; justify-content: center; align-items: center; margin-left: auto; margin-right: auto; font-size: 15px; width: 150px"><%= link_to 'More sensor data', grafana_more_data(@device_story.device_urn, true), target: :_blank %></button>
+      <button type="button" style="display: flex; justify-content: center; align-items: center; margin-left: auto; margin-right: auto; font-size: 15px; width: 150px"><%= link_to 'More sensor data', grafana_more_data(@device_story.device_urn, true), target: :_blank %></button>
     </div>
     <iframe
       src="<%= grafana_iframe(@device_story.device_urn, grafana_panel(:air_quality), true) %>"
       style="flex: 0 0 74%; width: 100%; height: 250px;" frameborder="0">
     </iframe>
   </div>
+  <hr>
   <div class="" style="min-height: 250px; height: calc(100vh - 325px); display: flex; flex-direction: column;">
     <iframe
       src="<%= grafana_iframe(@device_story.device_urn, grafana_panel(:air_quality_map), true) %>"

--- a/app/views/device_stories/show_mobile.html.erb
+++ b/app/views/device_stories/show_mobile.html.erb
@@ -12,9 +12,9 @@ Invalid URN. Help page is work in progress.
     </h2>
   </div>
   <hr>
-  <div class="" style="display: flex; flex-wrap: wrap; justify-content: space-around;">
-    <div style="max-width: 155px; margin-bottom: 50px">
-      <table class="table table-hover" style="margin-left: auto; margin-right: auto; min-width: 164px; table-layout: fixed; margin-top: 10%; word-wrap: break-word">
+  <div style="display: flex; flex-wrap: wrap; justify-content: space-around;">
+    <div style="flex: 1 5 25%; width: 100%; margin-top: 25px">
+      <table class="table table-hover" style="width: 100%">
         <thead style="font-size: 13px">
         <tr>
           <td colspan="3" style="text-align:center"><%= @device_story.last_seen %></td>
@@ -34,12 +34,16 @@ Invalid URN. Help page is work in progress.
             <br> ug/m3
           </td>
         </tr>
+        <tr>
+          <td colspan="3">
+            <button type="button" style="display: flex; justify-content: center; align-items: center; margin-left: auto; margin-right: auto; font-size: 15px; min-width: 164px; width: 100%"><%= link_to 'More sensor data', grafana_more_data(@device_story.device_urn, true), target: :_blank %></button>
+          </td>
+        </tr>
       </table>
-      <button type="button" style="display: flex; justify-content: center; align-items: center; margin-left: auto; margin-right: auto; font-size: 15px; width: 150px"><%= link_to 'More sensor data', grafana_more_data(@device_story.device_urn, true), target: :_blank %></button>
     </div>
     <iframe
       src="<%= grafana_iframe(@device_story.device_urn, grafana_panel(:air_quality), true) %>"
-      style="flex: 0 0 74%; width: 100%; height: 250px;" frameborder="0">
+      style="flex: 2 2 74%; width: 100%; height: 250px;" frameborder="0">
     </iframe>
   </div>
   <hr>

--- a/app/views/device_stories/show_mobile.html.erb
+++ b/app/views/device_stories/show_mobile.html.erb
@@ -1,3 +1,4 @@
+<div class="container" style="width: auto"><header><h1><%= link_to "Safecast", root_path %></h1></header></div>
 <%- unless @device_story%>
   <%= render 'help_page' %>
 <%- else %>

--- a/app/views/device_stories/show_mobile.html.erb
+++ b/app/views/device_stories/show_mobile.html.erb
@@ -1,5 +1,5 @@
 <%- unless @device_story%>
-Invalid URN. Help page is work in progress.
+  <%= render 'help_page' %>
 <%- else %>
   <%= content_for(:title) do %>
   <%- end -%>

--- a/app/views/device_stories/show_mobile.html.erb
+++ b/app/views/device_stories/show_mobile.html.erb
@@ -1,0 +1,50 @@
+<%- unless @device_story%>
+Invalid URN. Help page is work in progress.
+<%- else %>
+  <%= content_for(:title) do %>
+  <%- end -%>
+  <div style="margin-left: 10px">
+    <h2>
+    <%= @device_story.last_location_name %> (<%= @device_story.device_urn %>)
+    <%- if  @device_story.last_seen %>
+      <div style="font-size: 15px"> <%= time_ago_in_words(@device_story.last_seen) %> ago</div>
+    <%- end %>
+    </h2>
+  </div>
+  <div class="" style="display: flex; flex-wrap: wrap; justify-content: space-evenly;">
+    <div style="max-width: 155px">
+      <table class="table table-hover" style="margin-left: auto; margin-right: auto; min-width: 164px; table-layout: auto; margin-top: 10%; word-wrap: break-word">
+        <thead style="font-size: 13px">
+        <tr>
+          <td colspan="3" style="text-align:center"><%= @device_story.last_seen %></td>
+        </tr>
+        </thead>
+        <tr>
+          <td colspan="2" style="font-size: 12px">CPM</td>
+          <td style="font-size: 15px; text-align:right"> <%= last_cpm_values(@device_story.last_values) %></td>
+        </tr>
+        <tr>
+          <td colspan="2" style="font-size: 12px; white-space: nowrap">Battery Voltage</td>
+          <td style="font-size: 15px; text-align:right"><%= last_battery_value(@device_story.last_values) %>V</td>
+        </tr>
+        <tr>
+          <td style="font-size: 12px; white-space: nowrap"> Air Quality</td>
+          <td colspan="2" style="font-size: 12px; text-align:right"><%= last_air_quality_values(@device_story.last_values) %>
+            <br> ug/m3
+          </td>
+        </tr>
+      </table>
+      <button type="button" style="  display: flex; justify-content: center; align-items: center; margin-left: auto; margin-right: auto; font-size: 15px; width: 150px"><%= link_to 'More sensor data', grafana_more_data(@device_story.device_urn, true), target: :_blank %></button>
+    </div>
+    <iframe
+      src="<%= grafana_iframe(@device_story.device_urn, grafana_panel(:air_quality), true) %>"
+      style="flex: 0 0 74%; width: 100%; height: 250px;" frameborder="0">
+    </iframe>
+  </div>
+  <div class="" style="min-height: 250px; height: calc(100vh - 325px); display: flex; flex-direction: column;">
+    <iframe
+      src="<%= grafana_iframe(@device_story.device_urn, grafana_panel(:air_quality_map), true) %>"
+      style="flex-grow: 1; width: 100%; min-height: 250px; height: auto;" frameborder="0">
+    </iframe>
+  </div>
+<%- end %>

--- a/app/views/layouts/full_width_device_stories.html.erb
+++ b/app/views/layouts/full_width_device_stories.html.erb
@@ -27,7 +27,7 @@
 <div class="container-fluid">
       <%= render 'shared/flash', flash: flash %>
       <%= yield %>
-  <footer class="row">
+  <footer style="display: flex">
     <p class="span12"><%= t 'creative_commons_non_commercial' %></p>
     <p class="span12"><%= link_to_switch_locale %></p>
   </footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   scope '(:locale)', constraints: { locale: /(en-US|ja)/ } do # rubocop:disable Metrics/BlockLength
     get '/radiation_index' => 'radiation_index#radiation_index'
     get '/ingest' => 'ingest#index'
+
+    get '/airnote/:device_urn' => 'device_stories#show_mobile'
+
     root to: 'dashboards#show'
     devise_for :users
     devise_for :admins


### PR DESCRIPTION
- URLs of a pattern such as https://api.safecast.org/airnote/note:dev:865284040122792 are routed to a new responsive device story page which include air quality diagrams instead of the cpm diagrams
- If the device urn is invalid a help page is displayed instead (still work in progress)
<img width="383" alt="Screenshot 2021-01-08 at 10 25 20" src="https://user-images.githubusercontent.com/40150445/103963159-f0671400-519b-11eb-852d-f758a320594c.png">
<img width="783" alt="Screenshot 2021-01-08 at 10 25 38" src="https://user-images.githubusercontent.com/40150445/103963202-083e9800-519c-11eb-8e77-c21644c579a5.png">
