### PR TITLE
Fix version of cryptography to 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+cryptography==3.3.2
 awsebcli
 awscli


### PR DESCRIPTION
Since 3.4, it uses rust compiler.

To fix [this problem](https://safecast.slack.com/archives/C026F2Q1U/p1613092646150100).