### PR TITLE
Create container image for AWS CLI and eb cli

### DIFF
--- a/.elasticbeanstalk/config.global.yml
+++ b/.elasticbeanstalk/config.global.yml
@@ -1,7 +1,12 @@
 global:
   application_name: api
-  default_platform: arn:aws:elasticbeanstalk:us-west-2::platform/Puma with Ruby 2.4 running on 64bit Amazon Linux/2.11.1
   default_ec2_keyname: safecastapi
+  default_platform: Puma with Ruby 2.6 running on 64bit Amazon Linux
   default_region: us-west-2
-  profile: safecast
+  include_git_submodules: true
+  instance_profile: null
+  platform_name: null
+  platform_version: null
+  profile: null
   sc: git
+  workspace_type: Application

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ log/localeapp.yml
 .direnv
 .byebug_history
 
-.elasticbeanstalk/config.yml
-.elasticbeanstalk/app_versions/
-.elasticbeanstalk/saved_configs/
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libgeos-dev \
   libproj-dev \
   nodejs \
-  postgresql-client-11 \
-  python3 \
-  python3-pip \
-  python3-setuptools \
-  python3-wheel
+  postgresql-client-11
 
 WORKDIR /src
-ADD Gemfile Gemfile.lock .ruby-version requirements.txt /src/
-RUN LC_ALL=en_US.UTF-8 pip3 install -r requirements.txt
+ADD Gemfile Gemfile.lock .ruby-version /src/
 RUN bundle install --jobs=4 --retry=3
 
 CMD [ "bundle", "exec", "rails", "server", "-b", "0.0.0.0" ]

--- a/Dockerfile.aws-cli
+++ b/Dockerfile.aws-cli
@@ -1,0 +1,23 @@
+#
+# Dockerfile for aws-cli
+#
+# To build:
+#
+#  $ docker build -f Dockerfile.aws-cli -t aws-cli:latest
+#
+# To run:
+#
+#  $ docker run --rm -it --env-file <(aws-vault exec safecast --no-session -- env | grep --color=no '^AWS_') -v $(pwd):/aws aws-cli:latest
+#
+# You need to run aws-vault before running.
+
+FROM amazon/aws-cli:latest
+
+RUN yum group install -y "Development Tools" && \
+yum install -y zlib-devel openssl-devel ncurses-devel libffi-devel \
+sqlite-devel.x86_64 readline-devel.x86_64 bzip2-devel.x86_64
+RUN git clone https://github.com/aws/aws-elastic-beanstalk-cli-setup.git
+RUN ./aws-elastic-beanstalk-cli-setup/scripts/bundled_installer
+RUN echo 'export PATH="~/.pyenv/versions/3.7.2/bin:~/.ebcli-virtual-env/executables:$PATH"' >> ~/.bashrc
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,18 @@ services:
       - "127.0.0.1:${SC_API_POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+  aws-cli:
+    build:
+      context: .
+      dockerfile: Dockerfile.aws-cli
+    env_file:
+      # generate this file with aws-vault
+      #
+      #   $ aws-vault exec safecast --no-session -- env | grep --color=no '^AWS_' > aws-cli.env
+      #
+      - aws-cli.env
+    volumes:
+      - .:/aws
 
 volumes:
   elasticsearch-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-cryptography==3.3.2
-awsebcli
-awscli


### PR DESCRIPTION
This PR create separate container image for AWS CLI and eb CLI.

To pass credential to container, you should use aws-vault. For example,

```
$ aws-valut exec safecast -- env | grep --color=no '^AWS_' > aws-cli.env
$ docker-compose --build aws-cli
...
```