### PR TITLE
Update device stories from 0 lon/lat

### DIFF
--- a/app/models/device_story.rb
+++ b/app/models/device_story.rb
@@ -4,4 +4,16 @@ class DeviceStory < ApplicationRecord
   validates :device_urn, uniqueness: true
   validates :device_urn, :custodian_name, presence: true
   has_many  :device_story_comments, dependent: :destroy
+
+  def update_from_ttserve(metadata)
+    self.device_id = metadata['device']
+    self.last_seen = metadata['when_captured']
+    self.custodian_name = metadata['device_contact_name']
+
+    last_lon, last_lat = metadata.values_at('loc_lon', 'loc_lat')
+    return unless last_lon.present? && last_lat.present?
+
+    self.last_location = "POINT(#{last_lon} #{last_lat})"
+    self.last_location_name = metadata['location']
+  end
 end

--- a/app/safecast/tasks/device_stories/update_metadata.rb
+++ b/app/safecast/tasks/device_stories/update_metadata.rb
@@ -15,30 +15,13 @@ module Tasks
 
       private
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
       def find_or_update_device(device_urn, metadata)
-        last_lon, last_lat = metadata.values_at('loc_lon', 'loc_lat')
-
-        if last_lon.blank? || last_lat.blank?
-          Rails.logger.warn "Missing points for device_urn[#{device_urn}]"
-          return
-        end
-
         device = DeviceStory.find_or_initialize_by(device_urn: device_urn)
-
-        device.device_id = metadata['device']
-        device.last_seen = metadata['when_captured']
-        device.last_location = "POINT(#{last_lon} #{last_lat})"
-        device.last_location_name = metadata['location']
-        device.custodian_name = metadata['device_contact_name']
-
+        device.update_from_ttserve(metadata)
         device.save!
       rescue ActiveRecord::RecordInvalid
         Rails.logger.warn "Could not update device metadata for device_urn[#{device_urn}]"
       end
-      # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
 
       def each_metadata(metadatas)
         metadatas.each do |metadata|

--- a/spec/safecast/tasks/device_stories/update_metadata_spec.rb
+++ b/spec/safecast/tasks/device_stories/update_metadata_spec.rb
@@ -25,17 +25,5 @@ RSpec.describe Tasks::DeviceStories::UpdateMetadata do
           .from('Rob').to('Sean Bonner')
       end
     end
-
-    context 'when coordinates are missing' do
-      it 'skips device_story' do
-        expect(Rails).to receive_message_chain(:logger, :warn)
-          .with('Missing points for device_urn[note:dev:864475040512211]')
-
-        subject
-
-        expect(DeviceStory.find_by(device_urn: 'note:dev:864475040512211'))
-          .to be_nil
-      end
-    end
   end
 end


### PR DESCRIPTION
I noticed on http://tt.safecast.org/devices that note:dev:864475041086603 was showing up with a 0 lon/lat.

But the data has location info: https://grafana.safecast.cc/d/7wsttvxGk/safecast-airnote?orgId=1&var-device_urn=note:dev:864475041086603&from=now-3h&to=now

Figure we should probably just go ahead an import devices even ttserve can't tell us location info.

Note, I moved processing into the model to avoid the Metrics/MethodLength, Metrics/AbcSize issue.

Could also make it a helper function or something, but seemed reasonable to give DeviceStory a way to update itself from ttserve data.

Based on @rayozzie 's thoughts, maybe we can next work on an `update_from_elasticsearch` or something to reduce dependency on the ttserve API.