### PR TITLE
Download Postgres RPMs by  curl with insecure option 

### DIFF
--- a/.ebextensions/postgresql.config
+++ b/.ebextensions/postgresql.config
@@ -2,10 +2,16 @@ commands:
   upgrade_postgres:
     command: |
       /usr/bin/yum -y remove 'postgres*'
-      /usr/bin/yum -y install \
-        'https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/postgresql11-libs-11.6-1PGDG.rhel6.x86_64.rpm' \
-        'https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/postgresql11-11.6-1PGDG.rhel6.x86_64.rpm' \
+      /usr/bin/curl -sSL -k -O \
+        'https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/postgresql11-libs-11.6-1PGDG.rhel6.x86_64.rpm'
+      /usr/bin/curl -sSL -k -O \
+        'https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/postgresql11-11.6-1PGDG.rhel6.x86_64.rpm'
+      /usr/bin/curl -sSL -k -O \
         'https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/postgresql11-devel-11.6-1PGDG.rhel6.x86_64.rpm'
+      /usr/bin/yum install -y \
+        ./postgresql11-libs-11.6-1PGDG.rhel6.x86_64.rpm \
+        ./postgresql11-11.6-1PGDG.rhel6.x86_64.rpm \
+        ./postgresql11-devel-11.6-1PGDG.rhel6.x86_64.rpm
       /bin/ln -sf /usr/pgsql-11/bin/pg_config /usr/bin/pg_config
 
 files:


### PR DESCRIPTION
This Is a temporary solution.

We should migrate to Amazon Linux 2. See [this page](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.migration-al.html?icmpid=docs_elasticbeanstalk_console).

---

Deployed to safecastapi-dev-032 and safecastapi-dev-wrk-032, they seem to be fine.