### PR TITLE
Fix for Amazon Linux 2 Platform

### DIFF
--- a/.ebextensions/postgresql.config
+++ b/.ebextensions/postgresql.config
@@ -5,6 +5,9 @@ commands:
 files:
   "/etc/profile.d/z_psql.sh":
     content: |
+      DATABASE_HOST=$(/opt/elasticbeanstalk/bin/get-config environment | jq -r 'with_entries(select(.key == "DATABASE_HOST")) | .[]')
+      DATABASE_PASSWORD=$(/opt/elasticbeanstalk/bin/get-config environment | jq -r 'with_entries(select(.key == "DATABASE_PASSWORD")) | .[]')
+
       export PGHOST="${DATABASE_HOST}"
       export PGPORT=5432
       export PGDATABASE=safecast

--- a/.ebextensions/workers.config
+++ b/.ebextensions/workers.config
@@ -9,7 +9,7 @@ commands:
       VISIBILITY_TIMEOUT=$(/opt/elasticbeanstalk/bin/get-config meta -k sqsdconfig | jq -r .visibility_timeout)
       if [ -n "$VISIBILITY_TIMEOUT" ]; then
         echo "proxy_read_timeout ${VISIBILITY_TIMEOUT}s;" > /etc/nginx/conf.d/worker.conf
-        service nginx restart
+        systemctl restart nginx
       fi
   ensure_webapp_home_for_cron_execution:
     command: |

--- a/.platform/hooks/predeploy/02_create_public_system_directory.sh
+++ b/.platform/hooks/predeploy/02_create_public_system_directory.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+PUBLIC_SYSTEM_DIR=/var/app/staging/public/system
+if [ ! -e $PUBLIC_SYSTEM_DIR ]; then
+  mkdir -p $PUBLIC_SYSTEM_DIR
+fi


### PR DESCRIPTION
This PR fixes the following issues.

- No password in `.pgpass` because environment variables are not available
- Cause error when setting up `worker.config` in worker environment
- `public/system` is not available for new environment

Tried on [dev](https://github.com/Safecast/deployment-history/commit/6c84be0b99d7a5e58ad00e216236c1a89744d2ae), it seems to be working as expected.