### PR TITLE
Reduce execution frequency of dump_measurements_ios job

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -8,7 +8,7 @@ cron:
     schedule: "00 02 * * *"
   - name: dump_measurements_ios
     url: /cron
-    schedule: "33 */8 * * *"
+    schedule: "33 */12 * * *"
   - name: imbrogno_export
     url: /cron
     schedule: "00 02 * * 7"


### PR DESCRIPTION
It seems that it takes more than 8 hours to complete `dump_measurments_ios` job. Because of that, multiple jobs were running at same time. 

According log file, it takes 15 hours to complete. It might be because multiple jobs were running. I would like to try 12 hours, and observe how long this job would take when no other same jobs are running.

```
I, [2021-11-30T16:33:00.115649 #22270]  INFO -- : [aab5f8db-d22a-43b9-afab-84ef4409ef61] Started POST "/cron" for 127.0.0.1 at 2021-11-30 16:33:00 +0000
I, [2021-11-30T16:33:00.120492 #22270]  INFO -- : [aab5f8db-d22a-43b9-afab-84ef4409ef61] Processing by CronsController#create as HTML
I, [2021-11-30T16:33:00.120542 #22270]  INFO -- : [aab5f8db-d22a-43b9-afab-84ef4409ef61]   Parameters: {"cron"=>{}}
I, [2021-11-30T16:33:00.123460 #22270]  INFO -- : [aab5f8db-d22a-43b9-afab-84ef4409ef61] Starting cron task: dump_measurements_ios
```

```
I, [2021-12-01T07:38:18.247685 #22270]  INFO -- : [aab5f8db-d22a-43b9-afab-84ef4409ef61] Completed 200 OK in 54318127ms (Views: 1.5ms | Allocations: 12711236)
```
