### PR TITLE
Add czech and portuguese translations to locales

### DIFF
--- a/config/locales/cs-CZ.yml
+++ b/config/locales/cs-CZ.yml
@@ -1,0 +1,490 @@
+cs-CZ:
+  My_maps: Moje mapy
+  activerecord:
+    attributes:
+      bgeigie_import:
+        created_at: Nahráno dne
+        measurements_count: "# měření"
+        q: q
+        q_tooltip: Hledat
+        source: Zdroj
+        uploaded_after: Nahráno po
+        uploaded_before: Nahráno před
+        user_id: Uživatel
+      device:
+        manufacturer: Výrobce
+        measurements_count: Počet měření
+        model: Model
+        q: Hledat
+        sensor: Senzor
+        sensors: Senzory
+      measurement:
+        captured_after: Naměřeno po
+        captured_at: "Časová značka"
+        captured_before: Naměřeno před
+        device_id: ID zařízení
+        distance: Vzdálenost
+        latitude: Zeměpisná šířka
+        longitude: Zeměpisná délka
+        measurement_import_id: ID datového importu
+        sensor_id: Senzor
+        since: Od
+        unit: Jednotka
+        until: Do
+        user_id: ID uživatele
+        value: Hodnota
+      user:
+        email: Email
+        measurements_count: Počet měření
+        name: Jméno
+        password: Heslo
+        password_confirmation: Potvrzení hesla
+        remember_me: Zapamatovat
+    errors:
+      messages:
+        record_invalid: Záznam je neplatný
+      models:
+        bgeigie_import:
+          attributes:
+            source:
+              blank: nemůže být prázdné
+        device:
+          attributes:
+            sensors:
+              blank: nemůže být prázdné
+        measurement:
+          attributes:
+            sensor_id:
+              blank: nemůže být prázdné
+            unit:
+              blank: nemůže být prázdné
+            value:
+              blank: nemůže být prázdné
+  admin: Správce
+  api_docs: API dokumenty
+  are_you_sure: Jste si jist? Nelze vrátit zpět.
+  basics: Základy
+  bgeigie_import: Bgeigie import
+  bgeigie_imports: Bgeigie importy
+  bgeigie_states:
+    all: Vše
+    approved: Schváleno
+    error: Chyba
+    pending: "Čeká na vyřízení"
+  cancel: Storno
+  captured_at: změřeno_dne
+  cpm: cpm
+  creative_commons_non_commercial: Creative Commons - Neužívejte komerčně
+  dashboards:
+    show:
+      bgeigie_imports: bGeigie Importy
+      imports_awaiting_approval: Importy čekají na schválení
+      submissions: Předložená data
+  date:
+    abbr_day_names:
+    - Ne
+    - Po
+    - "Út"
+    - St
+    - "Čt"
+    - Pá
+    - So
+    abbr_month_names:
+    - 
+    - Led
+    - "Úno"
+    - Bře
+    - Dub
+    - Kvě
+    - "Čer"
+    - "Čvc"
+    - Srp
+    - Zář
+    - "Říj"
+    - Lis
+    - Pro
+    day_names:
+    - Neděle
+    - Pondělí
+    - "Úterý"
+    - Středa
+    - "Čtvrtek"
+    - Pátek
+    - Sobota
+    formats:
+      default: "%R-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    - 
+    - Leden
+    - "Únor"
+    - Březen
+    - Duben
+    - Květen
+    - "Červen"
+    - "Červenec"
+    - Srpen
+    - Září
+    - "Říjen"
+    - Listopad
+    - Prosinec
+    order:
+    - :rok
+    - :měsíc
+    - :den
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        few: kolem %{count} hodin
+        one: kolem 1 hodiny
+        other: kolem %{count} hodin
+      about_x_months:
+        few: kolem %{count} měsíců
+        one: kolem 1 měsíce
+        other: kolem %{count} měsíců
+      about_x_years:
+        few: kolem %{count} let
+        one: kolem 1 roku
+        other: kolem %{count} let
+      almost_x_years:
+        few: skoro %{count} roky
+        one: skoro 1 rok
+        other: skoro %{count} let
+      half_a_minute: půl minuty
+      less_than_x_minutes:
+        few: méně než %{count} minuty
+        one: méně než minuta
+        other: méně než %{count} minut
+      less_than_x_seconds:
+        few: méně než %{count} vteřiny
+        one: méně než vteřina
+        other: méně než %{count} vteřiny
+      over_x_years:
+        few: přes %{count} roky
+        one: přes 1 rok
+        other: přes %{count} let
+      x_days:
+        few: "%{count} dny"
+        one: 1 den
+        other: "%{count} dnů"
+      x_minutes:
+        few: "%{count} minuty"
+        one: 1 minuty
+        other: "%{count} minut"
+      x_months:
+        few: "%{count} měsíce"
+        one: 1 měsíc
+        other: "%{count} měsíců"
+      x_seconds:
+        few: "%{count} vteřiny"
+        one: 1 vteřina
+        other: "%{count} vteřin"
+    prompts:
+      day: Den
+      hour: Hodina
+      minute: Minuta
+      month: Měsíc
+      second: Vteřiny
+      year: Rok
+  delete: Smazat
+  devices:
+    index:
+      add_a_device: Přidat zařízení
+      devices: Zařízení
+      manufacturer: Výrobce
+      model: Model
+      no_devices: Nenalezena žádná zařízení
+      sensor: Senzor
+    new:
+      add_new: přidat_nové
+      add_new_device: Přidat nové zařízení
+  devise:
+    registrations:
+      inactive_signed_up: neaktivní registrace
+  edit_bgeigie_log_file: Upravit metadata bGeigie záznamu
+  edit_details_status: edit_details_status
+  edit_your_profile: Upravit vlastní profil
+  email: Email
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: musí být akceptováno
+      blank: nemůže zůstat prázdné
+      confirmation: neodpovídá potvrzení
+      empty: nemůže být prázdné
+      equal_to:
+        few: Musí být rovno %{count}
+        one: Musí být rovno
+        other: Musí být rovno %{count}
+      even: musí být sudý
+      exclusion: je rezervován
+      greater_than:
+        few: musí být větší než %{count}
+        one: musí být větší než %{count}
+        other: musí být větší než %{count}
+      greater_than_or_equal_to:
+        few: musí být větší než nebo rovno %{count}
+        one: musí být větší než nebo rovno %{count}
+        other: musí být větší než nebo rovno %{count}
+      inclusion: není zahrnuto v seznamu
+      invalid: je neplatný
+      less_than:
+        few: musí být menší než nebo rovno %{count}
+        one: musí být menší než nebo rovno %{count}
+        other: musí být menší než nebo rovno %{count}
+      less_than_or_equal_to:
+        few: musí být menší než %{count}
+        one: musí být menší než %{count}
+        other: musí být menší než %{count}
+      not_a_number: není číslo
+      not_an_integer: musí být celé číslo
+      not_saved: Neuloženo
+      odd: musí být lichý
+      record_invalid: 'Ověření selhalo: %{errors}'
+      taken: již se používá
+      too_long:
+        few: je příliš dlouhý (maximum jsou %{count} znaky)
+        one: je příliš dlouhý (maximum je 1 znak)
+        other: je příliš dlouhý (maximum je %{count} znaků)
+      too_short:
+        few: je příliš krátký (minumum jsou %{count} znaky)
+        one: je příliš krátký (minumum je 1 znak)
+        other: je příliš krátký (minumum je %{count} znaků)
+      wrong_length:
+        few: je chybné délky (měly být %{count} znaky)
+        one: je chybné délky (měl být 1 znak)
+        other: je chybné délky (mělo být %{count} znaků)
+    template:
+      body: 'Jsou zde problémy s následujícími poli:'
+      header:
+        few: "%{count} chyby zabránily uložení tohoto %{model}"
+        one: 1 chyba zabránila uložení tohoto %{model}
+        other: "%{count} chyb zabránilo uložení tohoto %{model}"
+  explore_maps_of_your_submissions: Pozkoumat mapy vašich měření
+  file: Soubor
+  file_exists: Tento soubor již existuje
+  filter: Filtr
+  from_here_you_can: Odsud můžete
+  height: Výška
+  hello: Ahoj
+  helpers:
+    select:
+      prompt: Prosím vyberte
+    submit:
+      bgeigie_import:
+        create: Nahrát
+        update: Uložit
+      create: Vytvořit %{model}
+      device:
+        create: Uložit
+        update: Uložit
+      submit: Uložit %{model}
+      update: Aktualizovat %{model}
+  id: ID
+  if_you_have_a_bgeigie: Pokud máte bGeigie
+  imports: Importy
+  imports_awaiting_approval: importy čekající na schválení
+  it_may_take_a_few_minutes_to_process: Zpracování může pár minut trvat.
+  lat: lat
+  layouts:
+    application:
+      api_home: API Domů
+      api_request: API požadavek
+      bgeigie_imports: bGeigie importy
+      change_password: Změnit heslo
+      dashboard: Hlavní panel
+      devices: Zařízení
+      edit_profile: Upravit profil
+      measurements: Měření
+      users: Uživatelé
+      your_profile: Můj profil
+    show_filters:
+      filters: Filtry
+    submit_nav:
+      submit_a_single_measurement: Vložit samostatné měření
+      upload_a_bgeigie_log_file: Nahrát bGeigie log soubor
+    summarize_results:
+      results: výsledky
+  lng: lng
+  manufacturer: Výrobce
+  maps: mapy
+  measured_with: Měřeno s
+  measurements: Měření
+  model: Model
+  my_maps: Moje mapy
+  name: Název
+  newly_uploaded: Nově nahráno
+  no_bgeigie_log_files_have_been_uploaded: "Žádné bGegie log soubory nebyly nahrány"
+  no_devices: "Žádná zařízení"
+  no_maps_found: "Žádné mapy nenalezeny."
+  none_found: Nic nenalezeno.
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: Kč
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Bilion
+          million: Milion
+          quadrillion: Kvadrilion
+          thousand: Tisíc
+          trillion: Trilion
+          unit: jednotka
+      format:
+        delimiter: oddělovač
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            few: Bajty
+            one: Bajt
+            other: Bajtů
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: oddělovač
+    precision:
+      format:
+        delimiter: oddělovač
+  on_date: dne %{date}
+  or: nebo
+  please_note: Prosím berte v potaz
+  previous_label: Předchozí
+  profile: Profil
+  public: Veřejný
+  radiation_type: Typ radiace
+  remember_me: Zapamatovat
+  retrieve_your_api_key: Získat váš API klíč
+  review_your_bgeigie_log_file_submissions: Opravit předložená data z bGeigie
+  save: Uložit
+  sensor: Senzor
+  shared:
+    dashboard_navigation:
+      devices: Zařízení
+      imports: Importy
+      measurements: Měření
+  sign_in: Přihlásit se
+  sign_out: Odhlásit se
+  sign_up: Registrovat se
+  simple_form:
+    buttons:
+      cancel: storno
+      or: nebo
+    creating: Vytvářím...
+    error_notification:
+      default_message: 'Opravte prosím problémy níže:'
+    hints:
+      bgeigie_import:
+        cities: (oddělené čárkou. např. "Praha, Brno")
+        credits: (oddělené čárkou. např. "Sean Bonner, Pieter Franken")
+        height: "(v metrech)"
+    labels:
+      bgeigie_import:
+        cities: Města
+        credits: Autor
+        description: Popis
+        height: Výška senzoru
+        name: Nadpis
+        orientation: Orientace senzoru
+        source: Nahrát soubor
+      user:
+        default_locale: Výchozí jazyk
+        remember_me: Zapamatovat
+    'no': Ne
+    required:
+      html: <abbr title="required">*</abbr>
+      mark: "*"
+      text: vyžadováno
+    updating: Aktualizuji...
+    'yes': Ano
+  submissions: předložená data
+  submit: Předložit
+  submit_a_reading: Předložit měření
+  submit_a_reading_from_your_device: Předložit měření z přístroje
+  submitted: Předloženo
+  support:
+    array:
+      last_word_connector: ", a"
+      two_words_connector: a
+      words_connector: ","
+  surface_type: Typ povrchu
+  time:
+    am: dopol.
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: odpol.
+  time_zone: "Časová zóna"
+  unit: Jednotka
+  upload: Nahrát
+  uploaded_by: nahrál/a %{name}
+  user:
+    email: email
+    invalid: neplatný
+    name: jméno
+    new:
+      email: email
+      password: heslo
+      remember_me: zapamatovat
+    password: heslo
+    password_confirmation: potvrzení_hesla
+    remember_me: zapamatovat
+    signed_in: přihlášen
+    signed_out: odhlášen
+    signed_up: zaregistrován
+    unauthenticated: neověřený
+  user_subject: Resetovat instrukce k heslu
+  users:
+    index:
+      number_of_measurements: Počet měření
+      users: Uživatelé
+  usv: "μSv/h"
+  view: Zobrazit
+  view_the_safecast_api_docs: Zobrazit dokumentaci Safecast API
+  view_your_bgeigie_log_uploads: Zobrazit moje nahraná data z bGeigie
+  view_your_submission_history: Zobrazit historii předložených dat
+  welcome_to_the_api_center: Vítejte do Safecast API centra.
+  will_paginate:
+    next_label: Další &#8594;
+    page_entries_info:
+      multi_page: Zobrazuji %{model} %{from} - %{to} z %{count} celkem
+      multi_page_html: Zobrazuji %{model} <b>%{from} - %{to}</b> z <b>%{count}</b> celkem
+      single_page:
+        few: Zobrazuji všechny %{count} %{model}
+        one: Zobrazuji 1 %{model}
+        other: "Žádný %{model} nenalezen"
+      single_page_html:
+        few: Zobrazuji <b>všechny&nbsp;%{count}</b> %{model}
+        one: Zobrazuji <b>1</b> %{model}
+        other: "Žádný %{model} nenalezen"
+    page_gap: "&hellip;"
+    previous_label: "&#8592; Předchozí"
+  you_havent_submitted_any_measurements_yet: Zatím jste nepředložil žádná měření.
+  you_havent_uploaded_any_bgeigie_log_files: Nenahrál jste žádné bGeigie log soubory.
+  your_api_key: Váš API klíč
+  your_maps: Vaše mapy
+  your_measurement: Vaše měření
+  your_measurements: Vaše měření
+  yours: Vaše

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,0 +1,472 @@
+pt:
+  My_maps: Meus Mapas
+  activerecord:
+    attributes:
+      bgeigie_import:
+        created_at: Atualizado em
+        measurements_count: "# de Medidas"
+        q: q
+        q_tooltip: Buscar
+        source: Fonte
+        uploaded_after: Enviado depois de
+        uploaded_before: Enviado antes de
+        user_id: Usuário
+      device:
+        manufacturer: Fabricante
+        measurements_count: Número de Medidas
+        model: Modelo
+        q: Busca
+        sensor: Sensor
+        sensors: Sensores
+      measurement:
+        captured_after: Capturado depois de
+        captured_at: Timestamp
+        captured_before: Capturado Antes de
+        device_id: ID do Dispositivo
+        distance: Distância
+        latitude: Latitude
+        longitude: Longitude
+        measurement_import_id: ID da Importação de Dados
+        sensor_id: Sensor
+        since: Desde
+        unit: Unidade
+        until: Até
+        user_id: ID de Usuário
+        value: Valor
+      user:
+        email: Email
+        measurements_count: Número de Medidas
+        name: Nome
+        password: Senha
+        password_confirmation: Confirmação da Senha
+        remember_me: Lembrar de mim
+    errors:
+      messages:
+        record_invalid: O registro é inválido
+      models:
+        bgeigie_import:
+          attributes:
+            source:
+              blank: não pode ser branco
+        device:
+          attributes:
+            sensors:
+              blank: não pode ser branco
+        measurement:
+          attributes:
+            sensor_id:
+              blank: não pode ser branco
+            unit:
+              blank: não pode ser branco
+            value:
+              blank: não pode ser branco
+  admin: Administrador
+  api_docs: Documentação da API
+  are_you_sure: Você tem certeza? Não há como desfazer.
+  basics: Básico
+  bgeigie_import: Importar Bgeigie
+  bgeigie_imports: Importar bGeigie
+  bgeigie_states:
+    all: 
+    approved: 
+    error: 
+    pending: 
+  cancel: Cancelar
+  captured_at: 
+  cpm: 
+  creative_commons_non_commercial: Creative Commons Não-Comercial
+  dashboards:
+    show:
+      bgeigie_imports: 
+      imports_awaiting_approval: 
+      submissions: Submissões
+  date:
+    abbr_day_names:
+    - Dom
+    - Seg
+    - Ter
+    - Qua
+    - Qui
+    - Sex
+    - Sab
+    abbr_month_names:
+    - 
+    - Jan
+    - Fev
+    - Mar
+    - Abr
+    - Mai
+    - Jun
+    - Jul
+    - Ago
+    - Set
+    - Out
+    - Nov
+    - Dez
+    day_names:
+    - Domingo
+    - Segunda-feira
+    - Terça-feira
+    - Quarta-feira
+    - Quinta-feira
+    - Sexta-feira
+    - Sábado
+    formats:
+      default: "%d/%m/%Y"
+      long: "%d de %B de %Y"
+      short: "%d-%b"
+    month_names:
+    - 
+    - Janeiro
+    - Fevereiro
+    - Março
+    - Abril
+    - Maio
+    - Junho
+    - Julho
+    - Agosto
+    - Setembro
+    - Outubro
+    - Novembro
+    - Dezembro
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: Cerca de 1 hora
+        other: Cerca de %{count} horas
+      about_x_months:
+        one: Cerca de 1 mês
+        other: Cerca de %{count} meses
+      about_x_years:
+        one: Cerca de 1 ano
+        other: Cerca de %{count} anos
+      almost_x_years:
+        one: Quase 1 ano
+        other: Quase %{count} anos
+      half_a_minute: metade de um minuto
+      less_than_x_minutes:
+        one: Menos que um minuto
+        other: Menos que %{count} minutos
+      less_than_x_seconds:
+        one: Menos que 1 segundo
+        other: Menos que %{count} segundos
+      over_x_years:
+        one: Mais de 1 ano
+        other: Mais de %{count} anos
+      x_days:
+        one: 1 dia
+        other: "%{count} dias"
+      x_minutes:
+        one: '1 minuto '
+        other: "%{count} minutos"
+      x_months:
+        one: 1 mês
+        other: "%{count} meses"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
+    prompts:
+      day: Dia
+      hour: Hora
+      minute: Minuto
+      month: Mês
+      second: Segundos
+      year: Ano
+  delete: Apagar
+  devices:
+    index:
+      add_a_device: Adicionar Dispositivo
+      devices: Dispositivos
+      manufacturer: Fabricante
+      model: Modelo
+      no_devices: Nenhum Dispositivo Encontrado
+      sensor: Sensor
+    new:
+      add_new: 
+      add_new_device: Adicionar um Novo Dispositivo
+  devise:
+    registrations:
+      inactive_signed_up: 
+  edit_bgeigie_log_file: Editar meta dados do arquivo de registros bGeigie
+  edit_details_status: 
+  edit_your_profile: Editar seu perfil
+  email: Email
+  errors:
+    format: 
+    messages:
+      accepted: Deve ser Aceito
+      blank: Não pode ser em branco
+      confirmation: Não confere com a confirmação
+      empty: Não pode ser vazio
+      equal_to:
+        one: ''
+        other: Deve ser igual a %{count}
+      even: Deve ser par
+      exclusion: está reservado
+      greater_than:
+        one: ''
+        other: Deve ser maior do que %{count}
+      greater_than_or_equal_to:
+        one: ''
+        other: deve ser maior ou igual a %{count}
+      inclusion: não está incluso na lista
+      invalid: "é inválido"
+      less_than:
+        one: ''
+        other: deve ser menos que %{count}
+      less_than_or_equal_to:
+        one: ''
+        other: deve ser menos ou igual a %{count}
+      not_a_number: não é númerico
+      not_an_integer: deve ser um número inteiro
+      not_saved: Não salvo
+      odd: deve ser ímpar
+      record_invalid: 'Validação falhou: %{errors}'
+      taken: já foi tomado
+      too_long:
+        one: "é muito longo (o máximo é 1 caractere)"
+        other: "é muito longo (o máximo é %{count} caracteres)"
+      too_short:
+        one: "é muito curto (o mínimo é 1 caractere)"
+        other: "é muito curto (o mínimo é %{count} caracteres)"
+      wrong_length:
+        one: está com o comprimento errado (deve ser 1 caracter)
+        other: está com o comprimento errado (devem ser %{count} caracteres)
+    template:
+      body: 'Houveram problemas com os seguintes campos:'
+      header:
+        one: 1 erro não permitiu este %{model} ser salvo
+        other: "%{count} erros não permitiram este %{model} ser salvo"
+  explore_maps_of_your_submissions: Explore mapas das suas submissões
+  file: Arquivo
+  file_exists: Este arquivo já existe
+  filter: Filtro
+  from_here_you_can: Desde aqui você pode
+  height: Altura
+  hello: Olá
+  helpers:
+    select:
+      prompt: Por favor selecione
+    submit:
+      bgeigie_import:
+        create: Enviar
+        update: Salvar
+      create: Criar %{model}
+      device:
+        create: Salvar
+        update: Salvar
+      submit: Save %{model}
+      update: Atualizar %{model}
+  id: ID
+  if_you_have_a_bgeigie: Se você tiver um BGeigie
+  imports: 
+  imports_awaiting_approval: 
+  it_may_take_a_few_minutes_to_process: Pode levar alguns minutos para processar.
+  lat: lat
+  layouts:
+    application:
+      api_home: Nodo raiz da API
+      api_request: Solicitação de API
+      bgeigie_imports: 
+      change_password: Trocar Senha
+      dashboard: Painel de Controle
+      devices: Dispositivos
+      edit_profile: Editar Perfil
+      measurements: Medidas
+      users: Usuários
+      your_profile: Seu Perfil
+    show_filters:
+      filters: Filtros
+    submit_nav:
+      submit_a_single_measurement: Submeter uma medida unitária
+      upload_a_bgeigie_log_file: Enviar um arquivo de registro bGeigie
+    summarize_results:
+      results: resultados
+  lng: ando
+  manufacturer: Fabricante
+  maps: Mapas
+  measured_with: Medido com
+  measurements: Medidas
+  model: Modelo
+  my_maps: Meus mapas
+  name: Nome
+  newly_uploaded: Recentemente Enviado
+  no_bgeigie_log_files_have_been_uploaded: Nenhum arquivo de registro bGeigie foi enviado
+  no_devices: 
+  no_maps_found: Nenhum mapa encontrado.
+  none_found: Nenhum encontrado.
+  number:
+    currency:
+      format:
+        delimiter: 
+        format: 
+        precision: 
+        separator: 
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 
+    format:
+      delimiter: 
+      precision: 
+      separator: 
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: 
+        units:
+          billion: Bilhão
+          million: Milhão
+          quadrillion: Quatrilhão
+          thousand: Milhar
+          trillion: Trilhão
+          unit: 
+      format:
+        delimiter: 
+        precision: 
+        significant: 
+        strip_insignificant_zeros: 
+      storage_units:
+        format: 
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: 
+          kb: 
+          mb: 
+          tb: 
+    percentage:
+      format:
+        delimiter: 
+    precision:
+      format:
+        delimiter: 
+  on_date: em %{date}
+  or: ou
+  please_note: Por favor considere
+  previous_label: Anterior
+  profile: Perfil
+  public: Público
+  radiation_type: Tipo de Radiação
+  remember_me: Lembrar de mim
+  retrieve_your_api_key: Recupere sua chave de API
+  review_your_bgeigie_log_file_submissions: 'Revise os envios do seu arquivo de registros bGeigie '
+  save: Salvar
+  sensor: Sensor
+  shared:
+    dashboard_navigation:
+      devices: Dispositivos
+      imports: 
+      measurements: Medidas
+  sign_in: Acessar
+  sign_out: Sair
+  sign_up: Inscrever-se
+  simple_form:
+    buttons:
+      cancel: Cancelar
+      or: ou
+    creating: Criando...
+    error_notification:
+      default_message: 'Por favor revise os problemas abaixo:'
+    hints:
+      bgeigie_import:
+        cities: '(separados por vírgula, por exemplo: "Dublin, Tokyo")'
+        credits: '(separados por vírgula, por exemplo: "Sean Bonner, Pieter Franken)'
+        height: "(em metros)"
+    labels:
+      bgeigie_import:
+        cities: Cidades
+        credits: Créditos
+        description: Descrição
+        height: Altura do Sensor
+        name: Título
+        orientation: Orientação do Sensor
+        source: Enviar um Arquivo
+      user:
+        default_locale: Localidade Padrão
+        remember_me: 
+    'no': Não
+    required:
+      html: 
+      mark: 
+      text: Requerido
+    updating: Atualizando...
+    'yes': Sim
+  submissions: Submissões
+  submit: Submeter
+  submit_a_reading: Submeter uma Leitura
+  submit_a_reading_from_your_device: Submeter uma leitura do do seu dispositivo
+  submitted: Submetido
+  support:
+    array:
+      last_word_connector: ", e"
+      two_words_connector: e
+      words_connector: 
+  surface_type: Tipo de Superfície
+  time:
+    am: manhã
+    formats:
+      default: 
+      long: 
+      short: 
+    pm: tarde
+  time_zone: Fuso horário
+  unit: Unidade
+  upload: Enviar
+  uploaded_by: Enviado por %{name}
+  user:
+    email: 
+    invalid: 
+    name: 
+    new:
+      email: 
+      password: 
+      remember_me: 
+    password: 
+    password_confirmation: 
+    remember_me: 
+    signed_in: 
+    signed_out: 
+    signed_up: 
+    unauthenticated: 
+  user_subject: Instruções para redefinir instruções
+  users:
+    index:
+      number_of_measurements: Número de Medidas
+      users: Usuários
+  usv: 
+  view: Visualizar
+  view_the_safecast_api_docs: 'Visualizar documentação da API Safecast '
+  view_your_bgeigie_log_uploads: Vizualizar seus envios registros bGeigie
+  view_your_submission_history: Visualizar seu histórico de submissões
+  welcome_to_the_api_center: Bem-vindo a central da API Safecast
+  will_paginate:
+    next_label: Próximos &#8594;
+    page_entries_info:
+      multi_page:
+        one: 'Mostrando %{model} %{from} - %{to} de um total de %{count}  '
+        other: ''
+      multi_page_html:
+        one: 'Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de um total de <b>%{count} </b> '
+        other: ''
+      single_page:
+        one: Mostrando 1 %{model}
+        other: Mostrando todos %{count} %{model}
+      single_page_html:
+        one: Mostrando <b>1</b> %{model}
+        other: Mostrando <b>todos&nbsp;%{count}</b> %{model}
+    page_gap: |
+      &hellip;
+    previous_label: "&#8592; Anterior"
+  you_havent_submitted_any_measurements_yet: Você ainda não submeteu nenhuma medida.
+  you_havent_uploaded_any_bgeigie_log_files: Você não enviou nenhum arquivo de registro bGeigie
+  your_api_key: Sua chave de API
+  your_maps: Seus maps
+  your_measurement: Sua Medida
+  your_measurements: Suas Medidas
+  yours: Suas


### PR DESCRIPTION
*why*

There are translations in https://app.localeapp.com/projects/4489 which could be used. 

*what*

Add yaml files with translations in Czech and Portuguese to config/locales.

Rel: https://github.com/Safecast/safecastapi/issues/782
