### PR TITLE
Reset to default locale

### DIFF
--- a/spec/acceptance/user_profile_spec.rb
+++ b/spec/acceptance/user_profile_spec.rb
@@ -6,6 +6,8 @@ feature 'User Profile', type: :feature do
   let(:user) { Fabricate(:user) }
   before { sign_in(user) }
 
+  after(:all) { I18n.locale = I18n.default_locale }
+
   scenario 'viewing a user profile' do
     expect(page).to have_content(user.authentication_token)
   end

--- a/spec/models/device_story_comment_spec.rb
+++ b/spec/models/device_story_comment_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DeviceStoryComment, type: :model do
   describe '#save' do
     let(:comment) { described_class.new(image: upload_file, content: '_content_', user: user, device_story: device_story) }
 
+    # Workaround for ActiveStorage::IntegrityError, see https://github.com/rails/rails/issues/41991
     def file_upload(src, content_type, binary: false)
       path = Rails.root.join(src)
       original_filename = path.basename.to_s


### PR DESCRIPTION
Fixes #853

When locale is `:ja`, space between attribute name and message is removed.

TODO: i18n-ize error messages in `DeviceStoryComment` 