### PR TITLE
Create public/system directry in postdeploy stage

### DIFF
--- a/.platform/hooks/postdeploy/02_create_public_system_directory.sh
+++ b/.platform/hooks/postdeploy/02_create_public_system_directory.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+PUBLIC_SYSTEM_DIR=/var/app/staging/public/system
+if [ ! -e $PUBLIC_SYSTEM_DIR ]; then
+  mkdir -p $PUBLIC_SYSTEM_DIR
+fi


### PR DESCRIPTION
Some scripts like cron/dump_measurements need this directory.