### PR TITLE
Non-conflicting dump archive naming #873

### DIFF
--- a/cron/dump_measurements
+++ b/cron/dump_measurements
@@ -10,7 +10,8 @@ cd ../public/system
 
 psql -f "${CRON_DIR}/dump_measurements.sql"
 
-tar -czf measurements.tar.gz measurements-out.csv
+tar -czf measurements-out.tar.gz measurements-out.csv
 mv measurements-out.csv measurements.csv
+mv measurements-out.tar.gz measurements.tar.gz
 
 # Now this is available as https://api.safecast.org/system/measurements.tar.gz


### PR DESCRIPTION
Measurements `.csv` file gets fully generated at first with non-conflicting name (`measurements-out.csv`), and only then replaces an old one by renaming. Used the same approach for `tar.gz` file.