### PR TITLE
Use config/elastic_apm.yml instead

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,10 +15,6 @@ module Safecast
     config.action_mailer.delivery_job = 'ActionMailer::MailDeliveryJob' # default 6.0
     config.active_record.belongs_to_required_by_default = false
 
-    if config.respond_to?(:elastic_apm)
-      config.elastic_apm.active = ENV['ELASTIC_APM_SECRET_TOKEN'].present?
-    end
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/elastic_apm.yml
+++ b/config/elastic_apm.yml
@@ -1,0 +1,2 @@
+server_url: <%= ENV['ELASTIC_APM_SERVER_URL'] %>
+secret_token: <%= ENV['ELASTIC_APM_SECRET_TOKEN'] %>


### PR DESCRIPTION
According to [this page](https://www.elastic.co/guide/en/apm/agent/ruby/current/configuration.html),

> There are several ways to configure how Elastic APM behaves. We recommend using a config/elastic_apm.yml file:

