### PR TITLE
Require moment before bootstrap datetimepicker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,9 +244,6 @@ GEM
     formatted-dates (0.1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    haml (5.2.1)
-      temple (>= 0.8.0)
-      tilt
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,8 +9,8 @@
 //= require jquery_ujs
 //= require underscore
 //= require bootstrap-sprockets
-//= require bootstrap-datetimepicker
 //= require moment
+//= require bootstrap-datetimepicker
 //= require chartkick
 //= require highcharts
 //= require_tree ./application


### PR DESCRIPTION
In Javascript console when viewing "Safecast Api" page:

```
bootstrap-datetimepicker requires Moment.js to be loaded first
```