### PR TITLE
Order elements with NULL values to last

### DIFF
--- a/app/controllers/device_stories_controller.rb
+++ b/app/controllers/device_stories_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class DeviceStoriesController < ApplicationController
-  has_scope :order
+  has_scope :order do |_controller, scope, value|
+    # TODO: Use `nulls_last` Arel method in Rails 6.1
+    scope.order("#{value} NULLS LAST")
+  end
 
   before_action :authenticate_user!, only: %i(new create edit update destroy)
   before_action :fetch_device_story, only: %i(show)

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -6,7 +6,10 @@
 # @topic Devices
 #
 class DevicesController < ApplicationController
-  has_scope :order
+  has_scope :order do |_controller, scope, value|
+    # TODO: Use `nulls_last` Arel method in Rails 6.1
+    scope.order("#{value} NULLS LAST")
+  end
   has_scope :manufacturer do |_controller, scope, value|
     scope.where('manufacturer LIKE ?', "%#{value}%")
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,10 @@
 class UsersController < ApplicationController
   include Swagger::Blocks
 
-  has_scope :order
+  has_scope :order do |_controller, scope, value|
+    # TODO: Use `nulls_last` Arel method in Rails 6.1
+    scope.order("#{value} NULLS LAST")
+  end
   has_scope :name do |_controller, scope, value|
     scope.by_name(value)
   end

--- a/spec/controllers/device_stories_controller_spec.rb
+++ b/spec/controllers/device_stories_controller_spec.rb
@@ -11,7 +11,20 @@ RSpec.describe DeviceStoriesController, type: :controller do
 
       expect(assigns(:device_stories)).to eq(device_stories)
     end
+
+    context 'when order is specified' do
+      before do
+        device_stories.sample.update(last_seen: nil)
+      end
+
+      it 'orders with null values to last' do
+        get :index, params: { order: 'last_seen asc' }
+
+        expect(assigns(:device_stories).last).to have_attributes(last_seen: nil)
+      end
+    end
   end
+
   describe 'GET #show_airnote' do
     let!(:device_story) { Fabricate(:device_story) }
 

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DevicesController, type: :controller do
+  describe 'GET #index' do
+    let!(:devices) do
+      [1, 2, 3].map do |i|
+        Fabricate(:device, manufacturer: "Company-#{i}")
+      end
+    end
+
+    context 'when order is specified' do
+      before do
+        devices.slice(0..-2).each do |device|
+          device.update(measurements_count: rand(1..100))
+        end
+      end
+
+      it 'orders with null values to last' do
+        get :index, params: { order: 'measurements_count asc' }
+
+        expect(assigns(:devices).last).to have_attributes(measurements_count: nil)
+      end
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe UsersController, type: :controller do
+  describe 'GET #index' do
+    let!(:users) { Fabricate.times(3, :user) }
+
+    context 'when order is specified' do
+      before do
+        users.slice(0..-2).each do |device|
+          device.update(measurements_count: rand(1..100))
+        end
+      end
+
+      it 'orders with null values to last' do
+        get :index, params: { order: 'measurements_count asc' }
+
+        expect(assigns(:users).last).to have_attributes(measurements_count: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #660

This pull requests uses 'NULLS LAST' that has been standardized since SQL:2003 to order elements with `NULL` values to last instead of assigning default values.