### PR TITLE
Fix error in mesurements#index when only `distance` is specified

### DIFF
--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -24,7 +24,7 @@ class Measurement < ActiveRecord::Base
   end
 
   def self.nearby_to(lat, lng, distance)
-    return scoped unless lat.present? && lng.present? && distance.present?
+    return all unless lat.present? && lng.present? && distance.present?
 
     where("ST_DWithin(location, ST_GeogFromText('POINT (#{lng.to_f} #{lat.to_f})'), ?)", distance.to_i)
   end

--- a/spec/controllers/measurements_controller_spec.rb
+++ b/spec/controllers/measurements_controller_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe MeasurementsController, type: :controller do
   end
   let(:existing_measurement) { Fabricate(:measurement, user: user) }
 
+  describe 'GET #index' do
+    context 'when only distance is specified in parameter' do
+      before do
+        get :index, params: { distance: 1 }
+      end
+
+      it 'returns HTTP 200 OK' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
   describe 'POST #create', format: :json do
     before do
       post :create, params: { api_key: api_key, format: :json }.merge(post_params)


### PR DESCRIPTION
Errors like the following were recorded in New Relic:

```
undefined local variable or method `scoped' for #<Class:0x000000000b0c6448> Did you mean? scope unscoped
    //var/app/current/app/models/measurement:rb:27:in `nearby_to'
```

`scoped` class method has been deprecated since Rails 5. There was deprecation warning like:

```
DEPRECATION WARNING: Model.scoped is deprecated. Please use Model.all instead.
```

But, we missed it when upgrading to Rails 5.