### PR TITLE
Respond with HTTP 404 when invalid bGeigie import ID is specified

### DIFF
--- a/app/controllers/bgeigie_imports_controller.rb
+++ b/app/controllers/bgeigie_imports_controller.rb
@@ -105,6 +105,8 @@ class BgeigieImportsController < ApplicationController # rubocop:disable Metrics
     render(partial: params[:partial]) && return if params[:partial].present?
 
     respond_with @bgeigie_import
+  rescue ActiveRecord::RecordNotFound
+    respond_with({}, status: :not_found)
   end
 
   def create

--- a/spec/controllers/bgeigie_imports_controller_spec.rb
+++ b/spec/controllers/bgeigie_imports_controller_spec.rb
@@ -368,4 +368,19 @@ RSpec.describe BgeigieImportsController, type: :controller do
       expect(bgeigie_import).to have_attributes(status: 'processed')
     end
   end
+
+  describe 'GET #show', format: :json do
+    context 'when specifying non-existing ID' do
+      before do
+        import = Fabricate(:bgeigie_import)
+        import.destroy!
+
+        get :show, params: { id: import.id }, format: :json
+      end
+
+      it 'return HTTP 404 Not Found' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, HTTP 500 because `beige_imports#show` raises `ActivRecord::RecordNotFound'. https://one.newrelic.com/nr1-core/errors/overview/MTA1NzgxMnxBUE18QVBQTElDQVRJT058MTA1ODAyMjI?account=1057812&duration=604800000&filters=%28domain%3D%27APM%27%20AND%20type%3D%27APPLICATION%27%29&state=718e15f0-37ec-d46d-54bb-4e1bf7914645