### PR TITLE
ignore `ActionDispatch::Http::MimeNegotiation::InvalidType` from NewRelic error collector

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -23,6 +23,8 @@ common: &default_settings
 
   # Logging level for log/newrelic_agent.log
   log_level: info
+error_collector:
+  ignore_errors: "ActionController::RoutingError,ActionDispatch::Http::MimeNegotiation::InvalidType"
 
 
 # Environment-specific settings are in this section.


### PR DESCRIPTION
https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#error_collector-ignore_errors